### PR TITLE
build: Java 8 compatible variant of 2.1.13

### DIFF
--- a/telemetry_library/build.gradle.kts
+++ b/telemetry_library/build.gradle.kts
@@ -46,13 +46,14 @@ android {
     }
 
     compileOptions {
-        // Java 11 is the safest for compatibility
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
-//        isCoreLibraryDesugaringEnabled = true
+        // Java 8 bytecode so Java-8 consuming apps can use the AAR; desugaring backfills
+        // java.time.* (used throughout) onto minSdk 24.
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+        isCoreLibraryDesugaringEnabled = true
     }
     kotlinOptions {
-        jvmTarget = "11"
+        jvmTarget = "1.8"
     }
 
     buildFeatures {
@@ -123,8 +124,8 @@ dependencies {
     api(libs.androidx.room.runtime)
     api(libs.androidx.room.ktx)
 
-    // Desugaring - removed since we no longer use Java 8 time APIs
-    // implementation("com.android.tools:desugar_jdk_libs:2.0.4")
+    // Desugaring - backfills java.time.* etc. onto older Android runtimes for Java 8 builds
+    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.4")
 
     // ❌ REMOVE kotlin-stdlib from compileOnly — let apps provide it
     // compileOnly("org.jetbrains.kotlin:kotlin-stdlib")
@@ -154,7 +155,7 @@ afterEvaluate {
                 from(components["release"])
                 groupId = "com.github.NCG-Africa"
                 artifactId = "edge_telemetry_android"
-                version = sdkVersion
+                version = "$sdkVersion-java8"
             }
         }
     }


### PR DESCRIPTION
## What

Java 8 compatible build of the SDK at full parity with `master` (2.1.13). **Source is byte-identical to master** — Compose, services refactor, validation, and the 2.1.13 backend wire-format alignment are all intact. The only change is a 9-line build config diff.

## Why

The prior `java8-compatible-v2` branch predated the 2.1.13 refactor: it forked ~40 commits back, swapped `java.time.*` for a custom `DateTimeUtils` (which emits a *different* timestamp format than `Instant.now().toString()`, fighting the 2.1.13 wire-format alignment), and dropped Compose entirely. This supersedes it.

## How

- `sourceCompatibility`/`targetCompatibility` = `VERSION_1_8`, kotlin `jvmTarget = "1.8"` → Java-8 bytecode
- `isCoreLibraryDesugaringEnabled = true` + `desugar_jdk_libs:2.1.4` → backfills `java.time.*` onto minSdk 24, so timestamps stay identical to master's wire format
- publication `version = "2.1.13-java8"` → distinct JitPack coordinate

Compose does **not** require jvmTarget 11 — verified by a clean `:telemetry_library:assembleRelease` (only deprecation warnings, zero errors).

## Verification

```
./gradlew :telemetry_library:assembleRelease
BUILD SUCCESSFUL
```