### PR TITLE
EdgeRUM SDK audit + automated ticket worker

### DIFF
--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: code-review
+description: Review the changes since a fixed point (commit, branch, tag, or merge-base) along two axes — Standards (does the code follow this repo's documented coding standards?) and Spec (does the code match what the originating issue/PRD asked for?). Runs both reviews in parallel sub-agents and reports them side by side. Use when the user wants to review a branch, a PR, work-in-progress changes, or asks to "review since X".
+---
+
+Two-axis review of the diff between `HEAD` and a fixed point the user supplies:
+
+- **Standards** — does the code conform to this repo's documented coding standards?
+- **Spec** — does the code faithfully implement the originating issue / PRD / spec?
+
+Both axes run as **parallel sub-agents** so they don't pollute each other's context, then this skill aggregates their findings.
+
+The issue tracker should have been provided to you — run `/setup-matt-pocock-skills` if `docs/agents/issue-tracker.md` is missing.
+
+## Process
+
+### 1. Pin the fixed point
+
+Whatever the user said is the fixed point — a commit SHA, branch name, tag, `main`, `HEAD~5`, etc. If they didn't specify one, ask for it.
+
+Capture the diff command once: `git diff <fixed-point>...HEAD` (three-dot, so the comparison is against the merge-base). Also note the list of commits via `git log <fixed-point>..HEAD --oneline`.
+
+Before going further, confirm the fixed point resolves (`git rev-parse <fixed-point>`) and the diff is non-empty. A bad ref or empty diff should fail here — not inside two parallel sub-agents.
+
+### 2. Identify the spec source
+
+Look for the originating spec, in this order:
+
+1. Issue references in the commit messages (`#123`, `Closes #45`, GitLab `!67`, etc.) — fetch via the workflow in `docs/agents/issue-tracker.md`.
+2. A path the user passed as an argument.
+3. A PRD/spec file under `docs/`, `specs/`, or `.scratch/` matching the branch name or feature.
+4. If nothing is found, ask the user where the spec is. If they say there isn't one, the **Spec** sub-agent will skip and report "no spec available".
+
+### 3. Identify the standards sources
+
+Anything in the repo that documents how code should be written, such as `CODING_STANDARDS.md` or `CONTRIBUTING.md`.
+
+On top of whatever the repo documents, the Standards axis always carries the **smell baseline** below — a fixed set of Fowler code smells (_Refactoring_, ch.3) that applies even when a repo documents nothing. Two rules bind it:
+
+- **The repo overrides.** A documented repo standard always wins; where it endorses something the baseline would flag, suppress the smell.
+- **Always a judgement call.** Each smell is a labelled heuristic ("possible Feature Envy"), never a hard violation — and, like any standard here, skip anything tooling already enforces.
+
+Each smell reads *what it is* → *how to fix*; match it against the diff:
+
+- **Mysterious Name** — a function, variable, or type whose name doesn't reveal what it does or holds. → rename it; if no honest name comes, the design's murky.
+- **Duplicated Code** — the same logic shape appears in more than one hunk or file in the change. → extract the shared shape, call it from both.
+- **Feature Envy** — a method that reaches into another object's data more than its own. → move the method onto the data it envies.
+- **Data Clumps** — the same few fields or params keep travelling together (a type wanting to be born). → bundle them into one type, pass that.
+- **Primitive Obsession** — a primitive or string standing in for a domain concept that deserves its own type. → give the concept its own small type.
+- **Repeated Switches** — the same `switch`/`if`-cascade on the same type recurs across the change. → replace with polymorphism, or one map both sites share.
+- **Shotgun Surgery** — one logical change forces scattered edits across many files in the diff. → gather what changes together into one module.
+- **Divergent Change** — one file or module is edited for several unrelated reasons. → split so each module changes for one reason.
+- **Speculative Generality** — abstraction, parameters, or hooks added for needs the spec doesn't have. → delete it; inline back until a real need shows.
+- **Message Chains** — long `a.b().c().d()` navigation the caller shouldn't depend on. → hide the walk behind one method on the first object.
+- **Middle Man** — a class or function that mostly just delegates onward. → cut it, call the real target direct.
+- **Refused Bequest** — a subclass or implementer that ignores or overrides most of what it inherits. → drop the inheritance, use composition.
+
+### 4. Spawn both sub-agents in parallel
+
+Send a single message with two `Agent` tool calls. Use the `general-purpose` subagent for both.
+
+**Standards sub-agent prompt** — include:
+
+- The full diff command and commit list.
+- The list of standards-source files you found in step 3, **plus the smell baseline from step 3** pasted in full — the sub-agent has no other access to it.
+- The brief: "Report — per file/hunk where relevant — (a) every place the diff violates a documented standard: cite the standard (file + the rule); and (b) any baseline smell you spot: name it and quote the hunk. Distinguish hard violations from judgement calls — documented-standard breaches can be hard, but baseline smells are always judgement calls, and a documented repo standard overrides the baseline. Skip anything tooling enforces. Under 400 words."
+
+**Spec sub-agent prompt** — include:
+
+- The diff command and commit list.
+- The path or fetched contents of the spec.
+- The brief: "Report: (a) requirements the spec asked for that are missing or partial; (b) behaviour in the diff that wasn't asked for (scope creep); (c) requirements that look implemented but where the implementation looks wrong. Quote the spec line for each finding. Under 400 words."
+
+If the spec is missing, skip the Spec sub-agent and note this in the final report.
+
+### 5. Aggregate
+
+Present the two reports under `## Standards` and `## Spec` headings, verbatim or lightly cleaned. Do **not** merge or rerank findings — the two axes are deliberately separate (see _Why two axes_).
+
+End with a one-line summary: total findings per axis, and the worst issue _within each axis_ (if any). Don't pick a single winner across axes — that's the reranking the separation exists to prevent.
+
+## Why two axes
+
+A change can pass one axis and fail the other:
+
+- Code that follows every standard but implements the wrong thing → **Standards pass, Spec fail.**
+- Code that does exactly what the issue asked but breaks the project's conventions → **Spec pass, Standards fail.**
+
+Reporting them separately stops one axis from masking the other.

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: implement
+description: "Implement a piece of work based on a spec or set of tickets."
+disable-model-invocation: true
+---
+
+Implement the work described by the user in the spec or tickets.
+
+Use /tdd where possible, at pre-agreed seams.
+
+Run typechecking regularly, single test files regularly, and the full test suite once at the end.
+
+Once done, use /code-review to review the work.
+
+Commit your work to the current branch.

--- a/.claude/skills/tdd/SKILL.md
+++ b/.claude/skills/tdd/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: tdd
+description: Test-driven development. Use when the user wants to build features or fix bugs test-first, mentions "red-green-refactor", or wants integration tests.
+---
+
+# Test-Driven Development
+
+TDD is the red → green loop. This skill is the reference that makes that loop produce tests worth keeping: what a good test is, where tests go, the anti-patterns, and the rules of the loop. Every section applies on every cycle — consult them before and during the loop, not after.
+
+When exploring the codebase, read `CONTEXT.md` (if it exists) so test names and interface vocabulary match the project's domain language, and respect ADRs in the area you're touching.
+
+## What a good test is
+
+Tests verify behavior through public interfaces, not implementation details. Code can change entirely; tests shouldn't. A good test reads like a specification — "user can checkout with valid cart" tells you exactly what capability exists — and survives refactors because it doesn't care about internal structure.
+
+See [tests.md](tests.md) for examples and [mocking.md](mocking.md) for mocking guidelines.
+
+## Seams — where tests go
+
+A **seam** is the public boundary you test at: the interface where you observe behavior without reaching inside. Tests live at seams, never against internals.
+
+**Test only at pre-agreed seams.** Before writing any test, write down the seams under test and confirm them with the user. No test is written at an unconfirmed seam. You can't test everything — agreeing the seams up front is how testing effort lands on the critical paths and complex logic instead of every edge case.
+
+Ask: "What's the public interface, and which seams should we test?"
+
+## Anti-patterns
+
+- **Implementation-coupled** — mocks internal collaborators, tests private methods, or verifies through a side channel (querying the database instead of using the interface). The tell: the test breaks when you refactor but behavior hasn't changed.
+- **Tautological** — the assertion recomputes the expected value the way the code does (`expect(add(a, b)).toBe(a + b)`, a snapshot derived by hand the same way, a constant asserted equal to itself), so it passes by construction and can never disagree with the code. Expected values must come from an independent source of truth — a known-good literal, a worked example, the spec.
+- **Horizontal slicing** — writing all tests first, then all implementation. Bulk tests verify _imagined_ behavior: you test the _shape_ of things rather than user-facing behavior, the tests go insensitive to real changes, and you commit to test structure before understanding the implementation. Work in **vertical slices** instead — one test → one implementation → repeat, each test a **tracer bullet** that responds to what the last cycle taught you.
+
+## Rules of the loop
+
+- **Red before green.** Write the failing test first, then only enough code to pass it. Don't anticipate future tests or add speculative features.
+- **One slice at a time.** One seam, one test, one minimal implementation per cycle.
+- **Refactoring is not part of the loop.** It belongs to the review stage (see the `code-review` skill), not the red → green implementation cycle.

--- a/.claude/skills/tdd/mocking.md
+++ b/.claude/skills/tdd/mocking.md
@@ -1,0 +1,59 @@
+# When to Mock
+
+Mock at **system boundaries** only:
+
+- External APIs (payment, email, etc.)
+- Databases (sometimes - prefer test DB)
+- Time/randomness
+- File system (sometimes)
+
+Don't mock:
+
+- Your own classes/modules
+- Internal collaborators
+- Anything you control
+
+## Designing for Mockability
+
+At system boundaries, design interfaces that are easy to mock:
+
+**1. Use dependency injection**
+
+Pass external dependencies in rather than creating them internally:
+
+```typescript
+// Easy to mock
+function processPayment(order, paymentClient) {
+  return paymentClient.charge(order.total);
+}
+
+// Hard to mock
+function processPayment(order) {
+  const client = new StripeClient(process.env.STRIPE_KEY);
+  return client.charge(order.total);
+}
+```
+
+**2. Prefer SDK-style interfaces over generic fetchers**
+
+Create specific functions for each external operation instead of one generic function with conditional logic:
+
+```typescript
+// GOOD: Each function is independently mockable
+const api = {
+  getUser: (id) => fetch(`/users/${id}`),
+  getOrders: (userId) => fetch(`/users/${userId}/orders`),
+  createOrder: (data) => fetch('/orders', { method: 'POST', body: data }),
+};
+
+// BAD: Mocking requires conditional logic inside the mock
+const api = {
+  fetch: (endpoint, options) => fetch(endpoint, options),
+};
+```
+
+The SDK approach means:
+- Each mock returns one specific shape
+- No conditional logic in test setup
+- Easier to see which endpoints a test exercises
+- Type safety per endpoint

--- a/.claude/skills/tdd/tests.md
+++ b/.claude/skills/tdd/tests.md
@@ -1,0 +1,77 @@
+# Good and Bad Tests
+
+## Good Tests
+
+**Integration-style**: Test through real interfaces, not mocks of internal parts.
+
+```typescript
+// GOOD: Tests observable behavior
+test("user can checkout with valid cart", async () => {
+  const cart = createCart();
+  cart.add(product);
+  const result = await checkout(cart, paymentMethod);
+  expect(result.status).toBe("confirmed");
+});
+```
+
+Characteristics:
+
+- Tests behavior users/callers care about
+- Uses public API only
+- Survives internal refactors
+- Describes WHAT, not HOW
+- One logical assertion per test
+
+## Bad Tests
+
+**Implementation-detail tests**: Coupled to internal structure.
+
+```typescript
+// BAD: Tests implementation details
+test("checkout calls paymentService.process", async () => {
+  const mockPayment = jest.mock(paymentService);
+  await checkout(cart, payment);
+  expect(mockPayment.process).toHaveBeenCalledWith(cart.total);
+});
+```
+
+Red flags:
+
+- Mocking internal collaborators
+- Testing private methods
+- Asserting on call counts/order
+- Test breaks when refactoring without behavior change
+- Test name describes HOW not WHAT
+- Verifying through external means instead of interface
+
+```typescript
+// BAD: Bypasses interface to verify
+test("createUser saves to database", async () => {
+  await createUser({ name: "Alice" });
+  const row = await db.query("SELECT * FROM users WHERE name = ?", ["Alice"]);
+  expect(row).toBeDefined();
+});
+
+// GOOD: Verifies through interface
+test("createUser makes user retrievable", async () => {
+  const user = await createUser({ name: "Alice" });
+  const retrieved = await getUser(user.id);
+  expect(retrieved.name).toBe("Alice");
+});
+```
+
+**Tautological tests**: Expected value restates the implementation, so the test passes by construction.
+
+```typescript
+// BAD: Expected value is recomputed the way the code computes it
+test("calculateTotal sums line items", () => {
+  const items = [{ price: 10 }, { price: 5 }];
+  const expected = items.reduce((sum, i) => sum + i.price, 0);
+  expect(calculateTotal(items)).toBe(expected);
+});
+
+// GOOD: Expected value is an independent, known literal
+test("calculateTotal sums line items", () => {
+  expect(calculateTotal([{ price: 10 }, { price: 5 }])).toBe(15);
+});
+```

--- a/.github/workflows/claude-worker.yml
+++ b/.github/workflows/claude-worker.yml
@@ -1,0 +1,59 @@
+name: Claude Worker
+
+# Implements a ticket automatically when it is labeled "ready-to-work",
+# but only if none of its native GitHub blocking issues are still open.
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  # Gate: honor the issue's native GitHub blocking relationships (as created by
+  # /to-tickets). issue_dependencies_summary.blocked_by counts OPEN blockers only,
+  # so > 0 means a blocker is still open and we must not run.
+  gate:
+    if: github.event.label.name == 'ready-to-work'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: read
+    outputs:
+      should-run: ${{ steps.check.outputs.should-run }}
+    steps:
+      - id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          ISSUE: ${{ github.event.issue.number }}
+        run: |
+          blocked=$(gh api "repos/$REPO/issues/$ISSUE" \
+            --jq '.issue_dependencies_summary.blocked_by')
+          echo "Issue #$ISSUE open blockers: $blocked"
+          if [ "${blocked:-0}" -gt 0 ]; then
+            echo "Still blocked by open issue(s):"
+            gh api "repos/$REPO/issues/$ISSUE/dependencies/blocked_by" \
+              --jq '.[] | select(.state=="open") | "  - #\(.number) \(.title)"'
+            echo "should-run=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "No open blockers — clear to run."
+            echo "should-run=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  implement:
+    needs: gate
+    if: needs.gate.outputs.should-run == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: "--max-turns 25 --model sonnet"
+          prompt: |
+            /implement ticket #${{ github.event.issue.number }}. Work only this
+            ticket's scope. Branch issue-${{ github.event.issue.number }}. Open a
+            PR linked with 'Closes #${{ github.event.issue.number }}'. Do not merge.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ Android telemetry library (AAR) published via JitPack as `com.github.NCG-Africa:
 - **Kotlin:** 2.1.0 | **AGP:** 8.7.1
 - **Java:** 11 (source + target)
 - **Gradle:** 8.4+
-- **Current version:** 2.1.12
+- **Current version:** 2.1.13
 
 ## Project Structure
 

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ For complete event schemas, validation rules, and JSON examples, see:
 | **All Core Features** | ✅ | ✅ |
 | **Use Case** | Modern projects | Projects pinned to Java 8 bytecode |
 
-> The `-java8` build is byte-identical to the standard release — same source, same features (Compose included) — but compiled to Java 8 bytecode (`sourceCompatibility`/`targetCompatibility = 1.8`) with core-library desugaring backfilling `java.time.*`. Use it when your app's `compileOptions` are pinned to Java 8 and the standard AAR fails with "compiled by a more recent version of Java." It needs the same modern Gradle/AGP/Kotlin toolchain as the standard release. Truly legacy toolchains (AGP 7.x, Kotlin 1.8) should stay on `1.2.3-java8`.
+> The `-java8` build is byte-identical to the standard release — same source, same features (Compose included) — but compiled to Java 8 bytecode (`sourceCompatibility`/`targetCompatibility = 1.8`) with core-library desugaring backfilling `java.time.*`. Use it when your app's `compileOptions` are pinned to Java 8 and the standard AAR fails with "compiled by a more recent version of Java." It needs the same modern Gradle/AGP/Kotlin toolchain as the standard release. Truly legacy toolchains (AGP 7.x, Kotlin 1.8, Compose-free) should use `1.2.5-java8`, which backports the same 2.1.13 feature set onto that older toolchain.
 
 ### 🎯 **Choose Your Version**
 

--- a/README.md
+++ b/README.md
@@ -197,14 +197,16 @@ For complete event schemas, validation rules, and JSON examples, see:
 
 | Feature | **Java 11+ Version** | **Java 8 Version** |
 |---------|---------------------|--------------------|
-| **Latest Version** | `2.1.13` | `1.2.3-java8` |
-| **Java Requirement** | Java 11+ | Java 8+ |
-| **Gradle** | 8.4+ | 7.5.1+ |
-| **AGP** | 8.7.1+ | 7.2.2+ |
-| **Kotlin** | 2.1.0+ | 1.8.22+ |
-| **Jetpack Compose** | ✅ Full Support | ❌ Not Supported |
+| **Latest Version** | `2.1.13` | `2.1.13-java8` |
+| **Java Requirement** | Java 11+ | Java 8+ (core-library desugaring) |
+| **Gradle** | 8.4+ | 8.4+ |
+| **AGP** | 8.7.1+ | 8.7.1+ |
+| **Kotlin** | 2.1.0+ | 2.1.0+ |
+| **Jetpack Compose** | ✅ Full Support | ✅ Full Support |
 | **All Core Features** | ✅ | ✅ |
-| **Use Case** | Modern projects | Legacy/Enterprise |
+| **Use Case** | Modern projects | Projects pinned to Java 8 bytecode |
+
+> The `-java8` build is byte-identical to the standard release — same source, same features (Compose included) — but compiled to Java 8 bytecode (`sourceCompatibility`/`targetCompatibility = 1.8`) with core-library desugaring backfilling `java.time.*`. Use it when your app's `compileOptions` are pinned to Java 8 and the standard AAR fails with "compiled by a more recent version of Java." It needs the same modern Gradle/AGP/Kotlin toolchain as the standard release. Truly legacy toolchains (AGP 7.x, Kotlin 1.8) should stay on `1.2.3-java8`.
 
 ### 🎯 **Choose Your Version**
 
@@ -213,10 +215,10 @@ For complete event schemas, validation rules, and JSON examples, see:
 - **Modern Toolchain**: Latest Gradle, AGP, and Kotlin
 - **Future-Proof**: Receives all new features first
 
-#### **Java 8 Version (Legacy Support)**
-- **Enterprise Ready**: Perfect for legacy codebases
-- **Dagger 2 Compatible**: Works with Dagger 2 + KAPT setups
-- **Core Functionality**: All telemetry features except Compose
+#### **Java 8 Version (Java 8 bytecode)**
+- **Full Parity**: Identical to the standard release, Compose included
+- **Java 8 Bytecode**: For apps whose `compileOptions` are pinned to Java 8
+- **Desugaring**: `java.time.*` backfilled onto minSdk 24 via core-library desugaring
 
 ### 📱 **Runtime Requirements (Both Versions)**
 - **Minimum SDK**: `24` (Android 7.0+)
@@ -270,25 +272,24 @@ Add JitPack repository (same as above), then:
 
 ```kotlin
 dependencies {
-    implementation 'com.github.NCG-Africa:edge_telemetry_android:1.2.3-java8'
+    implementation 'com.github.NCG-Africa:edge_telemetry_android:2.1.13-java8'
 }
 ```
 
 **Requirements:**
-- **Java**: 8+ (with desugaring enabled)
-- **Gradle**: 7.5.1+
-- **AGP**: 7.2.2+
-- **Kotlin**: 1.8.22+ (for Kotlin projects)
-- **Features**: ❌ No Compose support
+- **Java**: 8+ (core-library desugaring enabled in the SDK)
+- **Gradle**: 8.4+
+- **AGP**: 8.7.1+
+- **Kotlin**: 2.1.0+ (for Kotlin projects)
+- **Features**: ✅ Full Compose support (identical to the standard release)
 
 ### 🎯 **When to Use Each Version**
 
 | Use Java 11+ Version | Use Java 8 Version |
 |---------------------|--------------------|
-| ✅ New projects | ✅ Legacy codebases |
-| ✅ Compose apps | ✅ Dagger 2 + KAPT |
-| ✅ Modern toolchain | ✅ Enterprise constraints |
-| ✅ Latest features | ✅ Gradual migration |
+| ✅ Java 11+ bytecode OK | ✅ `compileOptions` pinned to Java 8 |
+| ✅ Standard setup | ✅ "compiled by a more recent Java" errors |
+| ✅ Same features | ✅ Same features (Compose included) |
 
 ## 🛠 Quick Setup
 
@@ -548,7 +549,7 @@ class ProfileFragment : Fragment() {
 }
 ```
 
-#### For Jetpack Compose Navigation (Java 11+ Version Only)
+#### For Jetpack Compose Navigation
 
 **Automatic Tracking**
 ```kotlin
@@ -627,7 +628,7 @@ composable(
 }
 ```
 
-> **Note**: Compose features are only available in the Java 11+ version. For Java 8 projects, use Activity/Fragment-based navigation.
+> **Note**: Compose is fully supported in both the standard and `-java8` builds.
 
 ## 📖 Usage Examples
 
@@ -690,7 +691,7 @@ if (telemetryManager != null) {
 }
 ```
 
-### Jetpack Compose Screen Tracking (Java 11+ Version Only)
+### Jetpack Compose Screen Tracking
 
 ```kotlin
 @Composable
@@ -708,7 +709,7 @@ fun ProfileScreen(navController: NavController) {
 }
 ```
 
-> **Note**: Compose screen tracking is only available in the Java 11+ version. Java 8 version users should use Activity/Fragment lifecycle tracking.
+> **Note**: Compose screen tracking is available in both the standard and `-java8` builds.
 
 ### Manual Screen Tracking
 

--- a/README.md
+++ b/README.md
@@ -197,11 +197,11 @@ For complete event schemas, validation rules, and JSON examples, see:
 
 | Feature | **Java 11+ Version** | **Java 8 Version** |
 |---------|---------------------|--------------------|
-| **Latest Version** | `2.0.0` | `1.2.3-java8` |
+| **Latest Version** | `2.1.13` | `1.2.3-java8` |
 | **Java Requirement** | Java 11+ | Java 8+ |
 | **Gradle** | 8.4+ | 7.5.1+ |
-| **AGP** | 8.0+ | 7.2.2+ |
-| **Kotlin** | 1.9.0+ | 1.8.22+ |
+| **AGP** | 8.7.1+ | 7.2.2+ |
+| **Kotlin** | 2.1.0+ | 1.8.22+ |
 | **Jetpack Compose** | ✅ Full Support | ❌ Not Supported |
 | **All Core Features** | ✅ | ✅ |
 | **Use Case** | Modern projects | Legacy/Enterprise |
@@ -253,15 +253,15 @@ Add the dependency to your app's `build.gradle`:
 
 ```kotlin
 dependencies {
-    implementation 'com.github.NCG-Africa:edge_telemetry_android:2.0.0'
+    implementation 'com.github.NCG-Africa:edge_telemetry_android:2.1.13'
 }
 ```
 
 **Requirements:**
 - **Java**: 11+
 - **Gradle**: 8.4+
-- **AGP**: 8.0+
-- **Kotlin**: 1.9.0+ (for Kotlin projects)
+- **AGP**: 8.7.1+
+- **Kotlin**: 2.1.0+ (for Kotlin projects)
 - **Features**: ✅ Full Compose support
 
 #### **Java 8 Projects (Legacy/Enterprise)**

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,45 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.** _(Set to `yes` if this repo treats external PRs as feature requests; `/triage` reads this flag.)_
+
+When set to `yes`, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
+
+- **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
+- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
+- **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
+
+GitHub shares one number space across issues and PRs, so a bare `#42` may be either — resolve with `gh pr view 42` and fall back to `gh issue view 42`.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The **map** is a single issue with **child** issues as tickets.
+
+- **Map**: a single issue labelled `wayfinder:map`, holding the Notes / Decisions-so-far / Fog body. `gh issue create --label wayfinder:map`.
+- **Child ticket**: an issue linked to the map as a GitHub sub-issue (`gh api` on the sub-issues endpoint). Where sub-issues aren't enabled, add the child to a task list in the map body and put `Part of #<map>` at the top of the child body. Labels: `wayfinder:<type>` (`research`/`prototype`/`grilling`/`task`). Once claimed, the ticket is assigned to the driving dev.
+- **Blocking**: GitHub's **native issue dependencies** — the canonical, UI-visible representation. Add an edge with `gh api --method POST repos/<owner>/<repo>/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>`, where `<blocker-db-id>` is the blocker's numeric **database id** (`gh api repos/<owner>/<repo>/issues/<n> --jq .id`, _not_ the `#number` or `node_id`). GitHub reports `issue_dependencies_summary.blocked_by` (open blockers only — the live gate). Where dependencies aren't available, fall back to a `Blocked by: #<n>, #<n>` line at the top of the child body. A ticket is unblocked when every blocker is closed.
+- **Frontier query**: list the map's open children (`gh issue list --state open`, scoped to the map's sub-issues / task list), drop any with an open blocker (`issue_dependencies_summary.blocked_by > 0`, or an open issue in the `Blocked by` line) or an assignee; first in map order wins.
+- **Claim**: `gh issue edit <n> --add-assignee @me` — the session's first write.
+- **Resolve**: `gh issue comment <n> --body "<answer>"`, then `gh issue close <n>`, then append a context pointer (gist + link) to the map's Decisions-so-far.

--- a/docs/specs/network-schema-sanitization.md
+++ b/docs/specs/network-schema-sanitization.md
@@ -1,0 +1,165 @@
+# Android spec — unify network schema + URL sanitization
+
+Resolves wayfinder ticket **#40** (audit #2 + #6). Hub decisions **D3** (dotted `http.*`
+keys, ratified) and **D8** (strip all query by default, opt-in allowlist) are fixed input —
+linked, not re-litigated. Rides the unified envelope (#30). Evidence:
+`sdk-audit.yaml:76-99, 330-334` + file:line refs below.
+
+Plan-only. This is the implementation spec; no code is changed on this branch.
+
+## Problem
+
+Two disjoint network events exist under two names with **zero key overlap**, and only the
+unused one is legible server-side:
+
+- **`http_request`** — the *wired* interceptor (`core/TelemetryInterceptor.kt:39-49`, returned
+  by `createNetworkInterceptor()`, so this is what real traffic uses). Keys: `url`, `method`,
+  `response_code`, `latency_ms`, `request_size_bytes`, `response_size_bytes`. The Processor
+  reads `http.url` / `http.method` / `http.status_code` / `http.duration_ms` — **none of these
+  keys match**, so all automatic HTTP is **dark server-side**.
+- **`http.request`** — the manual `recordNetworkRequest()` public API
+  (`core/services/EventTrackingService.kt:101-126`). Keys are already the `http.*` set the
+  Processor reads, but the API is rarely used, so little real HTTP lands.
+
+URL sanitization is inconsistent across the three paths:
+
+| Path | URL handling |
+|---|---|
+| `TelemetryInterceptor` (wired) | strips query via `substringBefore('?')` — OK |
+| `EdgeTelemetryInterceptor` (public, **unwired**) | sends **full URL incl. query** into `http.url` + network breadcrumbs (`core/http/EdgeTelemetryInterceptor.kt:28,98`) |
+| `recordNetworkRequest()` | stores the **raw URL** unmodified (`EventTrackingService.kt:113`) |
+
+No path/PII redaction anywhere.
+
+## Fixed input (do not re-decide)
+
+- **D3** — `http.*` ratified: `http.url` (sanitized per D8), `http.method`, `http.status_code`,
+  `http.duration_ms`, `http.success`, `http.timestamp`, plus the optional pair
+  `http.request_size` / `http.response_size` (integer bytes). **`http.success` = 2xx only (D3a)**;
+  the Processor stores the flag verbatim. Android's interceptor migrates event name + keys; its
+  duplicate public-API network path is removed.
+- **D8** — strip all query strings by default; opt-in allowlist; applies to `http.url`, resource
+  names, breadcrumbs.
+
+## Decisions
+
+### 1. One event, one key set — `http.request`
+
+The single network event is **`http.request`** (two-part namespace, matching `app.crash`,
+`screen.duration`, `navigation`, `frame.summary`). The wired interceptor migrates
+`http_request` → `http.request` and re-keys onto the D3 set:
+
+| Wire key | Source (interceptor) | Notes |
+|---|---|---|
+| `http.url` | `request.url`, **query stripped** | sanitized per §3 |
+| `http.method` | `request.method` | |
+| `http.status_code` | `response?.code ?: 0` | `0` on transport failure |
+| `http.duration_ms` | `nanoTime` delta → ms | |
+| `http.success` | `code in 200..299` | **2xx-only, D3a** — not `< 400` |
+| `http.timestamp` | event time | **format/correctness owned by #41**; #40 does not set its own local-time value |
+| `http.request_size` | `request.body?.contentLength()` | optional; **omitted** when `< 0` (§4) |
+| `http.response_size` | `response.body?.contentLength()` | optional; **omitted** when `< 0` (§4) |
+
+Attributes flow through the existing `recordEvent(name, attributes)` → `flattenAttributes`
+path into the #30 envelope; `session.*` / `user.* `/ `sdk.*` enrichment is added there, not
+here.
+
+Renames vs today's wired interceptor: `url`→`http.url`, `method`→`http.method`,
+`response_code`→`http.status_code`, `latency_ms`→`http.duration_ms`,
+`request_size_bytes`→`http.request_size`, `response_size_bytes`→`http.response_size`; **add**
+`http.success`.
+
+### 2. Delete the manual `recordNetworkRequest()` path
+
+Per D3 ("duplicate public-API network path is removed") and pre-1.0 API freedom. Both ends go:
+
+- `TelemetryManager.recordNetworkRequest(...)` public method **and** its pre-init-queue branch
+  (`core/TelemetryManager.kt:506, 517`).
+- `EventTrackingService.recordNetworkRequest(...)` (`:101-126`).
+
+The wired interceptor becomes the **single** network path. No caller inside the SDK uses the
+manual method (verified: only the two `TelemetryManager` sites above). Apps on OkHttp+our
+interceptor are unaffected; apps on a **non-OkHttp** client (HttpURLConnection, Cronet, Ktor-CIO)
+lose manual HTTP capture — a fog item (§ Fog), graduated only if a real consumer needs it.
+
+### 3. Strip all query by default; defer the allowlist
+
+Every url-carrying path strips the full query string (`substringBefore('?')`, already correct in
+the wired interceptor). The wire behaviour with **no** allowlist configured is identical to an
+unconfigured allowlist, so this is fully D8-conformant. The **opt-in query-param allowlist**
+mechanism (`httpQueryAllowlist` config + selective rebuild) is **not built now** — deferred to
+fog, graduated when a consumer needs a specific non-sensitive param.
+
+`EdgeTelemetryInterceptor` (unwired, leaks full URL + query into `http.url` and breadcrumbs) is
+**deleted** here — this ticket owns the URL-leak fix that #37 deferred to #40. It is entirely
+unreferenced (only its own `TAG` constant), so deletion is inert.
+
+**No network breadcrumbs.** The surviving interceptor adds none today; #40 keeps it that way and
+does not port `EdgeTelemetryInterceptor`'s breadcrumb trail. D8's "applies to breadcrumbs" clause
+therefore has **no live android target** after this ticket. A sanitized network-breadcrumb trail
+for crash triage is a fog item.
+
+### 4. Failure + unknown-size edges
+
+- **Transport failure** (`IOException`, no response): still emit `http.request`, with
+  `http.status_code = 0` and `http.success = false`. This keeps timeouts / DNS failures visible.
+  **No `http.error` field** — it is not in the D3 ratified set; failure is fully signalled by
+  `success=false` + `status_code=0`. An `IOException` that propagates uncaught becomes an
+  `app.crash` on the #39 path.
+- **Unknown body length**: OkHttp's `contentLength()` returns `-1` for chunked/streamed bodies.
+  Today's `?: 0` coerces that to `0`, which reads as an empty body. Instead, when
+  `contentLength() < 0`, **omit** `http.request_size` / `http.response_size` entirely (true
+  "optional pair" — backend column stays null, not a false `0`).
+
+### 5. Out of scope — path/PII redaction
+
+D8 ratifies **query** stripping only. URL **path** PII (`/accounts/12345/balance`) needs route
+patterns the SDK cannot infer and is not in the hub contract. Path templating / redaction is
+**out of scope** for #40 — a fog item, and **flagged to the hub** (`edge_rum_spec`) as a
+cross-SDK gap.
+
+## Failing test
+
+`TelemetryInterceptorTest` — auto HTTP must produce the `http.*` key set with a stripped URL.
+Fails today (`http_request` + `url` keys, dark server-side); passes after the migration.
+
+```kotlin
+@Test
+fun `auto HTTP emits http_dot keys, 2xx success, no query string`() {
+    val recorded = slot<Map<String, Any>>()
+    every { telemetryManager.recordEvent("http.request", capture(recorded)) } returns null
+
+    server.enqueue(MockResponse().setResponseCode(200))
+    client.newCall(Request.Builder().url(server.url("/pay?token=SECRET&acct=123")).build()).execute()
+
+    val a = recorded.captured
+    assertEquals("http.request keys", true, a.containsKey("http.status_code"))
+    assertEquals(200, a["http.status_code"])
+    assertEquals(true, a["http.success"])
+    assertFalse("no query on the wire", (a["http.url"] as String).contains("?"))
+    assertFalse("no token leak", (a["http.url"] as String).contains("SECRET"))
+}
+
+@Test
+fun `transport failure emits status 0, success false, still recorded`() {
+    every { telemetryManager.recordEvent("http.request", capture(recorded)) } returns null
+    // point client at a dead port so chain.proceed throws IOException
+    runCatching { client.newCall(Request.Builder().url("http://127.0.0.1:1/x").build()).execute() }
+    assertEquals(0, recorded.captured["http.status_code"])
+    assertEquals(false, recorded.captured["http.success"])
+    assertFalse(recorded.captured.containsKey("http.error"))
+}
+```
+
+## Files touched (execution, downstream)
+
+| File | Change |
+|---|---|
+| `core/TelemetryInterceptor.kt` | event name `http_request`→`http.request`; re-key to `http.*`; add `http.success = code in 200..299`; omit size keys when `contentLength() < 0` |
+| `core/services/EventTrackingService.kt` | delete `recordNetworkRequest(...)` (`:101-126`) |
+| `core/TelemetryManager.kt` | delete public `recordNetworkRequest(...)` + its pre-init-queue branch (`:506, 517`) |
+| `core/http/EdgeTelemetryInterceptor.kt` | **delete file** (unwired, full-URL leak) |
+| `core/TelemetryInterceptorTest.kt` | the tests above |
+
+Depends on: #30 (envelope) for enrichment + serializer; coordinates with #41 (`http.timestamp`
+value/format) and #37 (this ticket owns the `EdgeTelemetryInterceptor` deletion #37 deferred).

--- a/docs/specs/unified-wire-envelope.md
+++ b/docs/specs/unified-wire-envelope.md
@@ -1,0 +1,84 @@
+# Android spec — unified wire envelope + `sdk.*` attributes
+
+Resolves wayfinder ticket **#30** (audit #3 / #11). Hub decisions **D2** (envelope), **D11** (`sdk.*`), **D1** (crash) are fixed input — see `NCG-Africa/edge_rum_spec` `SEMANTIC_CONVENTIONS.md` / `SPEC_V1_DECISIONS.md`. Evidence for current state: `sdk-audit.yaml` (repo root) + file:line refs below.
+
+Plan-only. This is the implementation spec; no code is changed on this branch.
+
+## Problem
+
+HEAD (`2.1.13`) ships **two** non-conformant envelopes:
+
+- **Path A** (all events + manual `recordCrash`) — `TelemetryHttpClient.kt:147-166`:
+  `{type:"batch", events[], batch_size, timestamp, device_id, location}`, sent unwrapped.
+- **Path B** (uncaught crashes + all `trackError`) — `FlutterCompatiblePayload.kt`, sent by `CrashRetryManager.sendCrashData` (`:131-145`):
+  `{timestamp, device_id, data:{tenant_id, location, timestamp, batch_size, events[]}}`, its own Gson + headers, crash attrs from `DeviceInfoCollector.getCrashAttributes()` (device+app+network only — **no `session.*`, no `user.*`**).
+
+The hub wants **one** `telemetry_batch` envelope everyone else already sends.
+
+## Decisions (from grilling #30)
+
+1. **One envelope, hard cutover.** SDK emits only `telemetry_batch`. No SDK-side dual-emit — old-format tolerance, if any, is the collector's concern (an app on an old SDK version keeps sending the old shape until it upgrades; the SDK can't control that, and `sdk.version` lets the backend tell conformant from legacy traffic).
+2. **`sdk.*` move to the body.** `sdk.version` + `sdk.platform` become **required common attributes** on every event. Drop the `X-SDK-Version` / `X-SDK-Platform` headers (`TelemetryHttpClient.kt:120-125`, `CrashRetryManager.kt:139-140`). `X-API-Key` stays.
+3. **Full serializer + envelope + attribute unification.** One envelope builder, one attribute-enrichment pipeline, one POST helper for both rails. Crash keeps only its distinct **flush/retry timing** (immediate flush, eviction-exempt storage, its own retry schedule).
+4. **Drop `tenant_id` from the body.** Tenant is identified server-side by `X-API-Key`.
+
+## Target envelope
+
+```json
+{
+  "type": "telemetry_batch",
+  "timestamp": "2026-07-16T09:41:00.123Z",
+  "batch_size": 5,
+  "events": [ { "type": "event", "eventName": "...", "timestamp": "...", "attributes": { ... } } ]
+}
+```
+
+- Top-level: `type` (literal `telemetry_batch`), `timestamp` (ISO 8601 **true UTC**, D6), `batch_size` (int), `events[]`. Nothing else.
+- **Removed top-level:** `device_id` (now `device.id` per-event attr), `location` (D2 — geo is collector-derived), `data{}` wrapper (Path B), `tenant_id`.
+- Per-event element unchanged in shape: `{type:"event"|"metric", eventName?, metricName?, value?, timestamp, attributes{}}`. `attributes` values are **natively typed** — no stringified bools/numbers (fixes Path B `is_fatal` string).
+
+## Common-attribute block (every event's `attributes`)
+
+Existing Path-A block stays (`TelemetryHttpClient.kt:170-234`): `app.*`, `device.*`, `user.*`, `session.*`, `network.type`. **Add:**
+
+| Attribute | Value | Source |
+|---|---|---|
+| `sdk.version` | `BuildConfig.SDK_VERSION` | required |
+| `sdk.platform` | `"android"` (D11 enum) | required |
+
+`device.platform` stays lowercase `"android"`; `network.type` stays in the D20 enum (`wifi`/`cellular`/`ethernet`/`offline`/`unknown`).
+
+## Crash as a standard event
+
+Crash stops being a separate envelope. It becomes an `app.crash` event built through the **same** `EventAttributes` enrichment as every other event, so it automatically carries `session.*`, `user.*`, `sdk.*` (kills the Path B gap — D1). Crash-specific keys are **unprefixed** per D1: `message`, `stacktrace`, `exception_type`, `cause`, `is_fatal` (real JSON bool), `handled`, `error_context`, `error_code`, `product_id`, `user_action`, `crash.breadcrumbs`. SDK never sends `crash_hash`/`severity` (server-computed).
+
+## Code changes
+
+| Area | Change |
+|---|---|
+| `core/models/` (`TelemetryDataOut`) | Rename wire `type` → `telemetry_batch`; delete `device_id` + `location` fields. |
+| `core/TelemetryHttpClient.kt:147-166` | Emit unified envelope; drop top-level `device_id`/`location`; add `sdk.version`/`sdk.platform` into `flattenAttributes` (`:170-234`). |
+| `core/TelemetryHttpClient.kt:120-125` | Remove `X-SDK-*` headers. |
+| `core/payload/FlutterCompatiblePayload.kt` | **Delete** `CrashBatchEnvelope` + `createCrashBatchEnvelope` overloads. |
+| `core/retry/CrashRetryManager.kt:131-145` | Drop bespoke Gson + `X-SDK-*` headers; build crash as an `app.crash` event via the shared enrichment; serialize + POST via the shared helper. Keep immediate-flush + eviction-exempt + retry schedule. |
+| `core/device/DeviceInfoCollector.kt:95` (`getCrashAttributes`) | Retire — crash uses full common enrichment, not this reduced set. |
+
+Single source of truth for the envelope + attribute enrichment; two flush *triggers* only.
+
+## Migration
+
+Hard cutover in the next SDK version. No dual-emit. Backend must accept `telemetry_batch` before/as clients upgrade; legacy `type:"batch"` traffic from un-upgraded apps is disambiguated by `sdk.version` (D17 drop-counters make legacy vs conformant observable).
+
+## Test plan
+
+Golden-JSON assertions (`src/test/`, Robolectric + Gson):
+
+1. **Envelope shape** — serialize a batch of one `event`, one `metric`; assert exact top-level keys `{type,timestamp,batch_size,events}`, `type == "telemetry_batch"`, and **absence** of `device_id`/`location`/`data`/`tenant_id`.
+2. **Common attrs** — assert every event's `attributes` contains `sdk.version` + `sdk.platform=="android"`, plus `device.id`, `session.id`, `user.id`.
+3. **Native types** — assert `is_fatal` serializes as JSON boolean, session counters as JSON ints (no quotes).
+4. **Crash unification** — force a crash; assert it rides `telemetry_batch` with the D1 unprefixed keys **and** carries `session.*` + `user.*` (the Path B regression guard).
+5. **Headers** — assert request has `X-API-Key`, and **no** `X-SDK-Version`/`X-SDK-Platform`.
+
+## Downstream
+
+These tickets spec their slice against this envelope: retire-Path-B (**#39**), network-unify (**#40**), timestamp (**#41**), interaction events (**#42**), trace/span (**#43**).

--- a/sdk-audit.yaml
+++ b/sdk-audit.yaml
@@ -1,0 +1,466 @@
+repo: NCG-Africa/edge_telemetry_android
+component_type: sdk
+platform: android
+language: Kotlin
+current_version: 2.1.13   # telemetry_library/build.gradle.kts:13 (sdkVersion), flows to BuildConfig.SDK_VERSION and Maven publication version
+build_variants: >
+  Branch/tag-based, NOT a Gradle product-flavor scheme (one 'release' variant per branch).
+  Mainline = Java 11 (build.gradle.kts:50-55), published as bare version (2.1.13).
+  Java 8 backport lives on separate branches/tags (java8-compatible-v3, java8-legacy-1.2.5),
+  compiled to VERSION_1_8/jvmTarget 1.8 and published with a "-java8" version suffix
+  (e.g. 2.1.13-java8, 1.2.5-java8). Same groupId/artifactId; only the version string differs.
+registry: jitpack   # groupId com.github.NCG-Africa, artifactId edge_telemetry_android (build.gradle.kts:155-158); consumers add https://jitpack.io (settings.gradle.kts:20)
+
+# --- SDK sections 1-7 ---
+
+# 1. Events emitted
+# CRITICAL: this SDK has TWO independent wire formats.
+#   Path A (batch/event path): TelemetryBatch -> TelemetryHttpClient.toJson() -> TelemetryDataOut,
+#     sent UNWRAPPED. Flattened dotted-key attributes. Covers ALL events + manual recordCrash().
+#     Evidence: core/TelemetryHttpClient.kt:132-234
+#   Path B (crash path): CrashReporter (installed UncaughtExceptionHandler + all trackError())
+#     -> FlutterPayloadFactory.createCrashBatchEnvelope() -> CrashBatchEnvelope, serialized as a
+#     raw Map by CrashRetryManager. Different envelope + different attribute namespace, NO session/user.
+#     Evidence: core/crash/CrashReporter.kt, core/payload/FlutterCompatiblePayload.kt:100-369, core/retry/CrashRetryManager.kt:131-137
+#   NOTE: core/events/JsonEventTracker.kt send methods are DEAD (log only, never hit network) — ignored below.
+events:
+  # ----- Path A envelope (top-level object serialized on the wire) -----
+  # type:"batch", events[], batch_size(int), timestamp(string ISO), device_id(string), location(string|null, always null in practice)
+  # Evidence: core/TelemetryHttpClient.kt:148-162. Each events[] element: type("event"|"metric"), eventName?, metricName?, value?, timestamp, attributes(flattened).
+
+  - name: session.started
+    trigger: SDK init, startNewSession(), and session-timeout rotation on foreground
+    evidence: core/TelemetryManager.kt:356-375 (emitSessionStartedEvent)
+    payload_fields:
+      - {field: session.id, type: string, unit: none, always_present: true}
+      - {field: session.start_time, type: string, unit: none, always_present: true}
+      - {field: session.is_first_session, type: bool, unit: none, always_present: true}
+      - {field: session.total_sessions, type: int, unit: none, always_present: true}
+      - {field: network.type, type: string, unit: none, always_present: true}
+
+  - name: session.finalized
+    trigger: endCurrentSession() (reason "manual") or session timeout on onStart (reason "timeout")
+    evidence: core/TelemetryManager.kt:405-421, 986
+    payload_fields:
+      - {field: session.reason, type: string, unit: none, always_present: true}
+
+  - name: navigation
+    trigger: Activity onActivityResumed, Fragment onFragmentResumed, Compose recordComposeScreenView
+    evidence: core/TelemetryActivityLifecycleObserver.kt:48-58; TelemetryFragmentLifecycleObserver.kt:28-38; core/TelemetryManager.kt:575-585
+    payload_fields:
+      - {field: navigation.from_screen, type: string, unit: none, always_present: true}
+      - {field: navigation.to_screen, type: string, unit: none, always_present: true}
+      - {field: navigation.method, type: string, unit: none, always_present: true}
+      - {field: navigation.route_type, type: string, unit: none, always_present: true}
+      - {field: navigation.has_arguments, type: bool, unit: none, always_present: true}
+      - {field: navigation.timestamp, type: string, unit: none, always_present: unknown}  # DRIFT: Compose=ISO string; Activity/Fragment=navEvent.timestamp (type unknown)
+
+  - name: screen.duration
+    trigger: recordScreenDuration() — Compose screen end, Fragment paused, Activity screen-timing end
+    evidence: core/TelemetryManager.kt:602-611
+    payload_fields:
+      - {field: screen.name, type: string, unit: none, always_present: true}
+      - {field: screen.duration_ms, type: int, unit: ms, always_present: true}
+      - {field: screen.exit_method, type: string, unit: none, always_present: true}
+      - {field: screen.timestamp, type: string, unit: none, always_present: true}
+
+  - name: screen_view
+    trigger: recordScreenView() (gated by enableLegacyScreenEvents, default off) AND Activity onActivityPaused (NOT gated)
+    evidence: core/TelemetryManager.kt:556-568; core/TelemetryActivityLifecycleObserver.kt:71-79
+    payload_fields:  # DRIFT: two different shapes under one wire name
+      - {field: screen_name, type: string, unit: none, always_present: true}
+      - {field: duration_ms, type: int, unit: ms, always_present: false}       # Activity path only
+      - {field: session_id, type: string, unit: none, always_present: false}   # Activity path only
+      - {field: timestamp, type: int, unit: ms, always_present: false}         # Activity path only, epoch millis
+
+  - name: http_request
+    trigger: TelemetryInterceptor.intercept() (the interceptor returned by createNetworkInterceptor())
+    evidence: core/TelemetryInterceptor.kt:39-49
+    payload_fields:
+      - {field: url, type: string, unit: none, always_present: true}           # query string stripped
+      - {field: method, type: string, unit: none, always_present: true}
+      - {field: response_code, type: int, unit: none, always_present: true}
+      - {field: latency_ms, type: int, unit: ms, always_present: true}
+      - {field: request_size_bytes, type: int, unit: bytes, always_present: true}
+      - {field: response_size_bytes, type: int, unit: bytes, always_present: true}
+
+  - name: http.request
+    trigger: recordNetworkRequest() public API (rival network schema; different name AND keys from http_request)
+    evidence: core/services/EventTrackingService.kt:101-126
+    payload_fields:
+      - {field: http.url, type: string, unit: none, always_present: true}      # NOT sanitized (raw url)
+      - {field: http.method, type: string, unit: none, always_present: true}
+      - {field: http.status_code, type: int, unit: none, always_present: true}
+      - {field: http.duration_ms, type: int, unit: ms, always_present: true}
+      - {field: http.timestamp, type: string, unit: none, always_present: true}
+      - {field: http.success, type: bool, unit: none, always_present: true}
+      - {field: http.request_body_size, type: int, unit: bytes, always_present: true}
+      - {field: http.response_body_size, type: int, unit: bytes, always_present: true}
+      - {field: http.error, type: string, unit: none, always_present: true}    # "none" default
+
+  - name: memory_pressure
+    trigger: EnhancedMemoryTracker / BasicMemoryTracker recordMemoryUsage (gated enableMemoryTracking)
+    evidence: core/MemoryTracker.kt:97-100, 244-247, createStandardizedMemoryEvent 296-338
+    payload_fields:
+      - {field: memory.pressure_level, type: string, unit: none, always_present: true}
+      - {field: memory.under_system_pressure, type: bool, unit: none, always_present: true}
+      - {field: memory.api_level, type: int, unit: none, always_present: true}
+      - {field: memory.tracking_method, type: string, unit: none, always_present: true}
+      - {field: memory.timestamp, type: int, unit: ms, always_present: true}   # epoch millis
+      - {field: memory.heap_used_mb, type: int, unit: none, always_present: false}   # MB (name-encoded)
+      - {field: memory.heap_max_mb, type: int, unit: none, always_present: false}
+      - {field: memory.heap_free_mb, type: int, unit: none, always_present: false}
+      - {field: memory.system_available_mb, type: int, unit: none, always_present: false}
+      - {field: memory.system_low_memory, type: bool, unit: none, always_present: false}
+      - {field: memory.app_memory_class_mb, type: int, unit: none, always_present: false}
+      - {field: memory.large_memory_class_mb, type: int, unit: none, always_present: false}
+      - {field: memory.system_total_mb, type: int, unit: none, always_present: false}
+      - {field: memory.system_threshold_mb, type: int, unit: none, always_present: false}
+      - {field: memory.native_heap_kb, type: int, unit: bytes, always_present: false}   # KB
+      - {field: memory.total_pss_kb, type: int, unit: bytes, always_present: false}      # KB
+      - {field: memory.process_pss_kb, type: int, unit: bytes, always_present: false}    # KB
+
+  - name: storage_usage
+    trigger: recordStorageUsage (gated enableStorageTracking)
+    evidence: core/MemoryTracker.kt:147-150; core/TelemetryMemoryUsage.kt:251
+    payload_fields:
+      - {field: storage.api_level, type: int, unit: none, always_present: true}
+      - {field: storage.tracking_method, type: string, unit: none, always_present: true}
+      - {field: storage.internal_total_mb, type: int, unit: none, always_present: false}   # MB
+      - {field: storage.internal_free_mb, type: int, unit: none, always_present: false}
+      - {field: storage.internal_usable_mb, type: int, unit: none, always_present: false}
+
+  - name: frame_drop
+    trigger: TelemetryFrameDropCollector (FrameMetrics API, active path) / LegacyPerformanceTracker (dead path); gated enableFrameTracking
+    evidence: core/TelemetryFrameDropCollector.kt:59-68; core/LegacyPerformanceTracker.kt:199-211
+    payload_fields:
+      - {field: frame.build_duration_ms, type: float, unit: ms, always_present: true}
+      - {field: frame.raster_duration_ms, type: float, unit: ms, always_present: true}
+      - {field: frame.total_duration_ms, type: float, unit: ms, always_present: true}
+      - {field: frame.severity, type: string, unit: none, always_present: true}   # recorded even for "low" — no filter
+      - {field: frame.target_fps, type: int, unit: none, always_present: true}
+      - {field: frame.tracking_method, type: string, unit: none, always_present: false}  # legacy variant only
+      - {field: frame.api_level, type: int, unit: none, always_present: false}           # legacy variant only
+      - {field: screen.name, type: string, unit: none, always_present: false}            # legacy variant only
+
+  - name: performance.frame_summary
+    trigger: LegacyPerformanceTracker.generatePerformanceSummary (dead path — legacy tracker not instantiated by factory)
+    evidence: core/LegacyPerformanceTracker.kt:230-245
+    payload_fields:
+      - {field: performance.avg_frame_time_ms, type: float, unit: ms, always_present: true}
+      - {field: performance.max_frame_time_ms, type: float, unit: ms, always_present: true}
+      - {field: performance.total_frames, type: int, unit: none, always_present: true}
+      - {field: performance.slow_frame_count, type: int, unit: none, always_present: true}
+      - {field: performance.very_slow_frame_count, type: int, unit: none, always_present: true}
+      - {field: performance.slow_frame_percentage, type: float, unit: none, always_present: true}
+      - {field: performance.very_slow_frame_percentage, type: float, unit: none, always_present: true}
+      - {field: performance.tracking_method, type: string, unit: none, always_present: true}
+      - {field: performance.api_level, type: int, unit: none, always_present: true}
+      - {field: screen.name, type: string, unit: none, always_present: true}
+
+  - name: telemetry.capabilities_initialized
+    trigger: capability init during initialization sequence (gated enableCapabilityEvents)
+    evidence: core/TelemetryManager.kt:749-757
+    payload_fields:
+      - {field: device_capabilities, type: string, unit: none, always_present: true}   # summary object coerced to attr value
+      - {field: network_capabilities, type: string, unit: none, always_present: true}
+      - {field: memory_status, type: string, unit: none, always_present: true}
+      - {field: initialization_timestamp, type: int, unit: ms, always_present: true}    # epoch millis
+
+  - name: user.profile.update
+    trigger: setUserProfile() / clearUserProfile()
+    evidence: core/TelemetryManager.kt:891-899
+    payload_fields:
+      - {field: user.name, type: string, unit: none, always_present: true}    # "" on clear
+      - {field: user.email, type: string, unit: none, always_present: true}
+      - {field: user.phone, type: string, unit: none, always_present: true}
+      - {field: user.profile_updated_at, type: string, unit: none, always_present: true}
+
+  - name: app.crash   # PATH A variant — via manual recordCrash() only. type:"event".
+    trigger: recordCrash(throwable) -> queued into batch AND persisted to telemetry_pending_crash.json
+    evidence: core/services/CrashReportingService.kt:86-131
+    payload_fields:
+      - {field: error.message, type: string, unit: none, always_present: true}        # <=1000
+      - {field: error.stack_trace, type: string, unit: none, always_present: true}    # <=2000
+      - {field: error.exception_type, type: string, unit: none, always_present: true} # <=255
+      - {field: error.context, type: string, unit: none, always_present: true}        # <=500
+      - {field: error.cause, type: string, unit: none, always_present: true}          # <=255
+      - {field: error.severity_level, type: string, unit: none, always_present: true}
+      - {field: error.is_fatal, type: bool, unit: none, always_present: true}         # JSON bool true
+      - {field: error.breadcrumbs, type: string, unit: none, always_present: true}    # JSON string <=800
+      - {field: error.breadcrumb_count, type: int, unit: none, always_present: true}
+
+  - name: app.crash   # PATH B variant — real uncaught crashes + all trackError(). DIFFERENT envelope + keys.
+    trigger: installed UncaughtExceptionHandler and all trackError() overloads
+    evidence: core/crash/CrashReporter.kt:59-227; core/payload/FlutterCompatiblePayload.kt:268-288
+    payload_fields:  # envelope: {timestamp, device_id, data:{tenant_id, location, timestamp, batch_size, events[]}}
+      - {field: message, type: string, unit: none, always_present: true}          # <=1000, "ClassName: msg"
+      - {field: stacktrace, type: string, unit: none, always_present: true}        # <=2000 (lowercase key)
+      - {field: exception_type, type: string, unit: none, always_present: true}    # <=255
+      - {field: error_context, type: string, unit: none, always_present: false}    # <=500
+      - {field: cause, type: string, unit: none, always_present: false}            # <=255
+      - {field: is_fatal, type: string, unit: none, always_present: true}          # STRINGIFIED bool "true"/"false"
+      - {field: product_id, type: string, unit: none, always_present: false}       # <=255
+      - {field: user_action, type: string, unit: none, always_present: false}      # <=500
+      - {field: error_code, type: string, unit: none, always_present: false}       # <=100
+      - {field: breadcrumbs, type: string, unit: none, always_present: false}      # JSON string
+      - {field: crash.thread, type: string, unit: none, always_present: false}         # uncaught handler only
+      - {field: crash.is_main_thread, type: string, unit: none, always_present: false} # stringified bool, uncaught handler only
+      # NOTE: Path B carries device.* + app.* + network.type ONLY (DeviceInfoCollector.getCrashAttributes). NO session.*, NO user.*.
+
+# 2. Common attributes — attached to EVERY Path-A event.
+# Injected by flattenAttributes() in core/TelemetryHttpClient.kt:170-234 from EventAttributes.
+common_attributes:
+  - {field: app.name, type: string, unit: none, always_present: true, evidence: TelemetryHttpClient.kt:174}
+  - {field: app.version, type: string, unit: none, always_present: true, evidence: TelemetryHttpClient.kt:175}
+  - {field: app.build_number, type: string, unit: none, always_present: true, evidence: TelemetryHttpClient.kt:176}
+  - {field: app.package_name, type: string, unit: none, always_present: true, evidence: TelemetryHttpClient.kt:177}
+  - {field: device.id, type: string, unit: none, always_present: true, evidence: TelemetryHttpClient.kt:187}
+  - {field: device.platform, type: string, unit: none, always_present: true, evidence: TelemetryHttpClient.kt:188}  # "android"
+  - {field: device.platform_version, type: string, unit: none, always_present: true, evidence: TelemetryHttpClient.kt:189}
+  - {field: device.model, type: string, unit: none, always_present: true, evidence: TelemetryHttpClient.kt:190}
+  - {field: device.manufacturer, type: string, unit: none, always_present: true, evidence: TelemetryHttpClient.kt:191}
+  - {field: device.brand, type: string, unit: none, always_present: true, evidence: TelemetryHttpClient.kt:192}
+  - {field: device.android_sdk, type: string, unit: none, always_present: true, evidence: TelemetryHttpClient.kt:193}   # SDK_INT as string
+  - {field: device.android_release, type: string, unit: none, always_present: true, evidence: TelemetryHttpClient.kt:194}
+  - {field: device.fingerprint, type: string, unit: none, always_present: true, evidence: TelemetryHttpClient.kt:195}
+  - {field: device.hardware, type: string, unit: none, always_present: true, evidence: TelemetryHttpClient.kt:196}
+  - {field: device.product, type: string, unit: none, always_present: true, evidence: TelemetryHttpClient.kt:197}
+  - {field: user.id, type: string, unit: none, always_present: true, evidence: TelemetryHttpClient.kt:207}   # throws if blank
+  - {field: user.name, type: string, unit: none, always_present: false, evidence: TelemetryHttpClient.kt:212}
+  - {field: user.email, type: string, unit: none, always_present: false, evidence: TelemetryHttpClient.kt:213}
+  - {field: user.phone, type: string, unit: none, always_present: false, evidence: TelemetryHttpClient.kt:214}
+  - {field: session.id, type: string, unit: none, always_present: true, evidence: TelemetryHttpClient.kt:217}
+  - {field: session.start_time, type: string, unit: none, always_present: true, evidence: TelemetryHttpClient.kt:218}  # key always emitted, value may be null
+  - {field: session.duration_ms, type: int, unit: ms, always_present: true, evidence: TelemetryHttpClient.kt:219}
+  - {field: session.event_count, type: int, unit: none, always_present: true, evidence: TelemetryHttpClient.kt:220}
+  - {field: session.metric_count, type: int, unit: none, always_present: true, evidence: TelemetryHttpClient.kt:221}
+  - {field: session.screen_count, type: int, unit: none, always_present: true, evidence: TelemetryHttpClient.kt:222}
+  - {field: session.visited_screens, type: string, unit: none, always_present: true, evidence: TelemetryHttpClient.kt:223}  # comma-joined
+  - {field: session.is_first_session, type: bool, unit: none, always_present: true, evidence: TelemetryHttpClient.kt:224}
+  - {field: session.total_sessions, type: int, unit: none, always_present: true, evidence: TelemetryHttpClient.kt:225}
+  - {field: network.type, type: string, unit: none, always_present: true, evidence: TelemetryHttpClient.kt:226}  # wifi/cellular/ethernet/unknown
+  # Custom attributes merged LAST and CAN override the above (TelemetryHttpClient.kt:231).
+
+# 3. Session logic
+session:
+  start_rule: >
+    Auto-starts at init. SessionService.initialize() generates a session id and increments persisted
+    total_sessions in SharedPreferences (core/services/SessionService.kt:38-48). Init sequence step 15
+    emits session.started (core/TelemetryManager.kt:341-375). Nested SessionManager starts a session in
+    its init{} block only when enableSessionTracking=true (core/session/SessionManager.kt:32-34).
+  idle_timeout: >
+    30 min (sessionTimeoutMs = 1_800_000, core/TelemetryConfig.kt:8). Enforced ONLY on app foreground
+    (onStart): hasSessionTimedOut() compares now - last_active_timestamp >= timeout
+    (core/services/SessionService.kt:122-128). last_active_timestamp written on background in onStop
+    (core/TelemetryManager.kt:443). No background timer.
+  max_duration: none   # no max-session-duration cap in SessionManager.kt / SessionService.kt
+  background_behavior: >
+    onStop (core/TelemetryManager.kt:431-447): flushes in-memory queue to offline storage, writes
+    last_active_timestamp, stops flush timer. Session is NOT ended on background — resumed on next
+    foreground if within idle timeout. Gated on enableLifecycleTracking.
+  id_format: >
+    NOT UUID. IdGenerator.generateId() = "${System.currentTimeMillis()}_${8 random [a-z0-9] via SecureRandom}"
+    e.g. 1736899200000_a3k9zq1m. Same format for device, session, and user ids
+    (core/ids/IdGenerator.kt:13-16, 64-78). java.util.UUID is imported but unused for ids.
+
+# 4. Transport
+transport:
+  endpoint_path: >
+    The full configured TelemetryConfig.endpoint URL is POSTed verbatim — no path appended/derived
+    (core/TelemetryHttpClient.kt:117-128). Deprecated init overload defaults it to
+    https://edgetelemetry.ncgafrica.com/collector/telemetry (core/TelemetryManager.kt:190); the
+    non-deprecated init requires the caller to supply it. Crash path (Path B) POSTs to the same endpoint.
+  serialization: json   # Gson. Path A = TelemetryDataOut sent unwrapped (TelemetryHttpClient.kt:166). Path B = CrashBatchEnvelope as raw Map (CrashRetryManager.kt:131-137).
+  compression: none      # no gzip/deflate interceptor, no Content-Encoding header anywhere
+  # HTTP: POST. Headers: Content-Type application/json; User-Agent EdgeTelemetryAndroid/<ver>;
+  #   X-API-Key <apiKey>; X-SDK-Version <ver>; X-SDK-Platform android (TelemetryHttpClient.kt:120-125).
+  #   Timeouts: connect 10s, write 30s, read 30s.
+  batching:
+    flush_interval: >
+      config.flushIntervalMs default 30_000 ms (core/TelemetryConfig.kt:7). BUG/FINDING: the scheduled
+      flush Runnable body is EMPTY (core/services/BatchProcessingService.kt:196-205) — the periodic timer
+      fires but flushes nothing. Sends are triggered only by queue-size threshold (maybeSendBatch,
+      TelemetryManager.kt:637-646) and by lifecycle transitions.
+    max_batch_size: 50   # config.batchSize default 50; shouldSendBatch = queueSize >= batchSize (BatchProcessingService.kt:61-63)
+    flush_on_background: true   # onStop flushes queue to OFFLINE STORAGE (SharedPreferences), NOT to network (TelemetryManager.kt:431-447)
+  retry:
+    strategy: >
+      Batch path: exponential backoff with jitter = 1000ms * 2^attempt + random(0..1000)
+      (core/TelemetryHttpClient.kt:111-114); retries only on 5xx and network exceptions, 4xx = immediate
+      fail. Crash path: exponential backoff base 1 min = 60s * 2^(attempt-1) (CrashRetryManager.kt:275-278);
+      HTTP 429 trips a process-wide 60s circuit breaker + WorkManager reschedule (CrashRetryManager.kt:98-107).
+    max_attempts: 3   # both paths (TelemetryHttpClient maxRetries=3; CrashRetryManager MAX_RETRIES=3)
+    drop_policy: >
+      Batch: on final failure store to offline storage if flushOffline=true, else DROP (events already
+      polled off the queue) (BatchProcessingService.kt:88-112). Crash: after 3 failures store to
+      cacheDir/pending_crashes.json + WorkManager retry; after 3 STORAGE failures crashes are dropped to
+      avoid a loop (CrashRetryManager.kt:122-165).
+  offline:
+    persistence: >
+      SharedPreferences + file (NO Room/SQLite despite androidx.room being declared in build.gradle.kts:123-124;
+      zero @Dao/@Entity/@Database in src/main). Batches: core/OfflineBatchStorage.kt stores the whole batch
+      list as one Gson JSON string in SharedPreferences ("telemetry_batches"/"stored_batches"). Crashes:
+      plain JSON file cacheDir/pending_crashes.json guarded by a FileLock (CrashRetryManager.kt:66,172-180).
+    caps: >
+      Batches: NO cap, NO eviction, unbounded growth; read-modify-write not atomic across concurrent stores.
+      Crashes: no size cap on the list (only the 3-failure storage circuit breaker); cacheDir may be OS-evicted.
+      In-memory eventQueue (ConcurrentLinkedQueue) also has NO max cap.
+  sampling_or_throttling: >
+    Checked all three paths (create/queue/send). Event creation (EventTrackingService.recordEvent/
+    recordMetric, :51-96): NO sampling, throttling, or dedup — every call unconditionally enqueued.
+    Queue: only gate is size>=batchSize send trigger; no per-event dropping; queue unbounded. Send: no
+    sampling; only the crash 429 circuit breaker throttles (crashes only). Frame events on the ACTIVE path
+    (TelemetryFrameDropCollector) are recorded UNSAMPLED and UNFILTERED — even severity="low" fires
+    (TelemetryFrameDropCollector.kt:57-69); the 10% sampler (SAMPLING_RATE=0.1) exists only in
+    LegacyPerformanceTracker which the factory NEVER instantiates (dead code, so frame sampling is
+    effectively OFF). CrashFingerprinter computes a fingerprint but it is NOT used for any client-side
+    dedup/suppression (transmitted only; dedup, if any, is server-side). Breadcrumbs capped at 50
+    (BreadcrumbManager MAX_BREADCRUMBS, circular buffer). Pre-init queue capped at 50 with FIFO eviction
+    (TelemetryManager.kt:83,1053-1057) — startup buffer cap, not runtime sampling. No general-event
+    sampling/rate-limiting anywhere.
+
+# 5. Privacy & data handling
+privacy:
+  ip_handling: >
+    Client-side IP/geo code EXISTS but is DEAD/unwired. IpLocationProvider (core/location/IpLocationProvider.kt)
+    can call ipinfo.io / api.ipify.org, but it is never instantiated — locationProvider is always null, so
+    even with enableLocationTracking=true no IP or geolocation is collected or sent. The batch top-level
+    'location' field is always null in practice. (Server still sees transport source IP; SDK sends none.)
+  url_sanitization: >
+    Inconsistent. TelemetryInterceptor (the wired one via createNetworkInterceptor) strips query via
+    substringBefore('?') (core/TelemetryInterceptor.kt:39-49). EdgeTelemetryInterceptor (NOT wired, but
+    public) sends the FULL url incl. query into http.url and network breadcrumbs (core/http/EdgeTelemetryInterceptor.kt:28,98).
+    recordNetworkRequest() stores the raw url unmodified (EventTrackingService.kt:113). No path/PII redaction.
+  user_identifiers: >
+    device_id — auto, persisted (edge_telemetry_ids/device_id), sent as device.id on every event.
+    user_id — auto-generated on first access, persisted (edge_telemetry_ids/edge_rum_user_id), never null,
+    sent as user.id. No public setter for user_id. session_id — auto per session. Plus full device
+    fingerprint (Build.FINGERPRINT/MODEL/MANUFACTURER/BRAND/HARDWARE/PRODUCT) sent on every event —
+    high-entropy, always on. Location/IP = opt-in flag but dead (see ip_handling).
+  pii_risks: >
+    User profile name/email/phone (developer-supplied, persisted in SharedPreferences, sent raw as
+    user.name/email/phone + user.profile.update event; no hashing/redaction). Crash/error message +
+    stack_trace + cause sent raw (can contain PII/secrets). Breadcrumbs = arbitrary developer strings +
+    data maps attached to crashes; network breadcrumbs include full URLs. Screen names = Activity title
+    or class name. No PII scrubbing/allowlist layer exists (only ApiKeyRedactionInterceptor, which
+    redacts the API key in LOGS only).
+
+# 6. Public API surface
+api:
+  init_config_options:
+    - apiKey (required; non-blank; must start with "edge_")
+    - endpoint (required; non-blank)
+    - batchSize (default 50)
+    - flushIntervalMs (default 30_000)
+    - sessionTimeoutMs (default 1_800_000 / 30 min)
+    - enableScreenTracking (default true)
+    - enableCrashReporting (default true)
+    - enableNetworkTracking (default true)
+    - enableLifecycleTracking (default true)
+    - enableMemoryTracking (default true)
+    - enableStorageTracking (default true)
+    - enableFrameTracking (default true)
+    - enableLegacyScreenEvents (default false)
+    - enableUserInteractionEvents (default true)
+    - enableCapabilityEvents (default true)
+    - enableSessionTracking (default true)
+    - enableLocationTracking (default false)   # NOTE: has no effect — location provider is dead code
+  custom_event_api: >
+    recordEvent(eventName: String, attributes: Map<String, Any> = emptyMap()) (TelemetryManager.kt:472);
+    recordMetric(metricName: String, value: Double, attributes: Map<String, Any> = emptyMap()) (:450)
+  user_id_api: >
+    No setter for user_id (auto-generated only). getUserId(): String (:1004, never null). Identity set via
+    setUserProfile(name: String?, email: String?, phone: String? = null) (:871) and clearUserProfile() (:882)
+  other_public_methods:
+    - "Companion: initialize(application, config) (:153); initialize(application, apiKey, batchSize, endpoint) @Deprecated (:186); getInstance() (:203); createNetworkInterceptor(): TelemetryInterceptor (:213)"
+    - recordNetworkRequest(...) (:495)
+    - recordCrash(throwable) (:524)
+    - recordError(...) @Deprecated (:537)
+    - trackComposeScreens(navController) @Composable (:544)
+    - recordScreenView(name) @Deprecated (:556)
+    - recordComposeScreenView(route) (:573)
+    - recordComposeScreenEnd(route) (:588)
+    - recordScreenDuration(name, durationMs, exitMethod) (:602)
+    - addBreadcrumb(message, category, level, data) (:904)
+    - trackError(error, attributes) (:916)
+    - trackError(error, errorCode, productId, userAction, attributes) (:929)
+    - trackError(message, stackTrace, attributes) (:942)
+    - setProductContext(productId) (:952)
+    - setLastUserAction(action) (:962)
+    - startNewSession() (:969)
+    - endCurrentSession() (:984)
+    - getDeviceId() (:996)
+    - getUserId() (:1004)
+    - getSessionId() (:1011)
+    - testCrashReporting(customMessage) (:1018)
+    - testConnectivity() (:1025)
+    - getDeviceCapabilities() (:768)
+    - getMemoryCapabilityTracker() (:775)
+    - getInterceptor(): Interceptor (:1083)
+    - "EdgeTelemetry = deprecated typealias for TelemetryManager"
+
+# 7. Feature checklist
+features:
+  session-tracking: {status: done, evidence: "core/services/SessionService.kt, core/session/SessionManager.kt, TelemetryManager onStart/init", notes: "30min idle timeout evaluated on foreground only; no max duration"}
+  view-tracking: {status: done, evidence: "core/TelemetryActivityLifecycleObserver.kt, compose/EdgeTelemetryCompose.kt, core/ScreenTimingTracker.kt", notes: "Activity auto + Compose opt-in via trackComposeScreens()"}
+  error-capture: {status: done, evidence: "core/services/CrashReportingService.kt, core/crash/CrashReporter.kt", notes: "trackError() overloads with errorCode/productId/userAction"}
+  crash-capture: {status: done, evidence: "core/crash/CrashReporter.kt:59-79 (UncaughtExceptionHandler), persisted to cacheDir/pending_crashes.json", notes: "Chains original handler; breadcrumbs attached; separate Path-B wire format"}
+  network-capture: {status: partial, evidence: "core/TelemetryInterceptor.kt (wired via createNetworkInterceptor()), core/http/EdgeTelemetryInterceptor.kt (NOT wired)", notes: "Manual — consumer must add interceptor; two divergent impls; two rival wire schemas (http_request vs http.request)"}
+  custom-events: {status: done, evidence: "core/TelemetryManager.kt:472/450, core/services/EventTrackingService.kt", notes: ""}
+  web-vitals: {status: na, evidence: "grep: no LCP/FCP/CLS/TTFB", notes: "Native Android; not applicable"}
+  app-start: {status: planned, evidence: "grep: no cold/warm-start timing code", notes: "Not implemented"}
+  anr-detection: {status: planned, evidence: "grep: no ANR/watchdog/main-thread-block code", notes: "Not implemented"}
+  hang-detection: {status: planned, evidence: "grep: none", notes: "Not implemented"}
+  frame-stats: {status: done, evidence: "core/TelemetryFrameDropCollector.kt (FrameMetrics API 24+, emits frame_drop)", notes: "Per-frame drop severity, gated enableFrameTracking; recorded unsampled/unfiltered"}
+  batching: {status: done, evidence: "core/services/BatchProcessingService.kt (size threshold config.batchSize)", notes: "Flush timer body EMPTY — timer fires but does nothing; sends are size/lifecycle-triggered only"}
+  offline-persistence: {status: partial, evidence: "core/OfflineBatchStorage.kt (SharedPreferences, NOT Room), core/retry/CrashRetryManager.kt (file-based)", notes: "CLAUDE.md claims Room; code uses SharedPreferences JSON blob (unbounded) + cache-dir file"}
+  retry-backoff: {status: done, evidence: "core/TelemetryHttpClient.sendWithRetry():63-114 (3 retries, exp backoff+jitter); core/retry/CrashRetryManager.kt (3 retries, exp backoff base 1min, 429 circuit breaker, WorkManager)", notes: "Two separate retry systems (batch vs crash)"}
+  no-sampling-guarantee: {status: done, evidence: "No sampling logic found in config/services/send paths", notes: "Effectively 100% capture; not an explicit guarantee. Only bounds: pre-init queue max 50 (drops oldest); dead 10% frame sampler in unused LegacyPerformanceTracker"}
+
+# --- 9. All repos ---
+inconsistencies_and_surprises: >
+  TWO INCOMPATIBLE CRASH WIRE FORMATS under the same eventName "app.crash": real uncaught crashes +
+  trackError (Path B) send {message, stacktrace, exception_type, is_fatal:"true"} string-keyed with NO
+  session/user context; manual recordCrash() (Path A) sends {error.message, error.stack_trace,
+  error.is_fatal:true} bool-keyed WITH session/user. is_fatal is JSON bool in Path A but a stringified
+  "true" in Path B.
+  TWO NETWORK EVENTS with different names AND keys: live interceptor -> http_request {url, response_code,
+  latency_ms, ...}; recordNetworkRequest -> http.request {http.url, http.status_code, http.duration_ms, ...}.
+  screen_view has two shapes (legacy {screen_name} vs Activity {screen_name, duration_ms, session_id, timestamp}).
+  TIMESTAMP FORMAT/UNIT DRIFT: batch/event timestamps use SimpleDateFormat("...'Z'") — literal Z appended
+  but formatted in the DEVICE's default timezone (not true UTC); crash path uses Instant.now().toString()
+  (true UTC with nanos); several attribute timestamps (memory.timestamp, screen_view timestamp,
+  initialization_timestamp) are raw epoch-millis ints. Mixed units within one payload.
+  DEAD CODE: IpLocationProvider never instantiated (location always null; enableLocationTracking is a no-op);
+  JsonEventTracker send methods are log-only stubs; LegacyPerformanceTracker (incl. the only frame sampler)
+  never selected by the factory; TelemetryPayload/EventBatchPayload/EdgeTelemetryInterceptor defined but not
+  on the live wire.
+  Flush timer Runnable body is EMPTY — time-based flushing does not occur.
+  Room declared as a dependency but unused; offline persistence is SharedPreferences (unbounded) + cache file
+  (contradicts CLAUDE.md's "Room-based offline persistence").
+  IDs are timestamp_random8, not UUID v4 (UUID imported but unused).
+  In-memory event queue and offline batch store are unbounded (no event/byte caps, no eviction).
+  Full high-entropy device fingerprint (Build.FINGERPRINT etc.) sent on every event.
+  No compression on any transport.
+ci_cd:
+  what_exists: >
+    One GitHub Actions workflow .github/workflows/gradle.yml ("Build Library"): triggers on push/PR to
+    branch 'main'; checkout@v4 -> setup-java@v4 (Temurin JDK 17) -> ./gradlew clean assembleRelease -x lint.
+    Build-only — no tests, no lint (explicitly skipped), no publish/artifact step. NOTE: the active default
+    branch is 'master', but the workflow triggers only on 'main' (a stale branch) — so CI effectively does
+    not run on master pushes/PRs.
+  publishes_to: >
+    JitPack, built on-demand by JitPack's servers when a consumer requests
+    com.github.NCG-Africa:edge_telemetry_android:<tag>. Triggered by git tags, NOT by the GitHub workflow.
+    No jitpack.yml on master/mainline (JitPack uses its default Gradle build); a jitpack.yml exists only on
+    branch java8-legacy-1.2.5 and hardcodes a stale -Pversion=1.2.3-java8 (2-patch drift vs that branch's
+    sdkVersion 1.2.5-java8). JDK spread across the pipeline: mainline compiles Java 11, Actions uses JDK 17,
+    java8 jitpack.yml pins openjdk11, java8 artifacts target Java 8 — no single pinned toolchain.
+
+open_questions:
+  - "navigation.timestamp type for the Activity/Fragment emitters (navEvent.timestamp) — string vs long unknown"
+  - "Whether the server-side collector expects Path A or Path B crash keys (or both) — SDK sends divergent schemas"
+  - "Whether JitPack has successfully built each published tag (no in-repo build-status evidence)"
+  - "Whether origin/main is abandoned or intentionally retained for the (now non-firing) CI trigger"
+  - "Type of the capability summary attribute values (device_capabilities/network_capabilities/memory_status) on the wire — coerced from summary objects"


### PR DESCRIPTION
Brings the EdgeRUM wire-format audit + conformance specs to `master`, and lands the automated ticket-implementation workflow.

## CI: Claude worker
- `.github/workflows/claude-worker.yml` — label an issue `ready-to-work` → gate on native GitHub issue-dependency blockers (`issue_dependencies_summary.blocked_by`, open blockers only) → `claude-code-action@v1` runs `/implement`, branches `issue-<n>`, opens a PR (`Closes #<n>`), no merge.
- `.claude/skills/{implement,tdd,code-review}` committed so they resolve in headless runs; `docs/agents/issue-tracker.md` (required by `/code-review`).

**Note:** `on: issues` workflows only fire once this is on the default branch — merging this enables the worker.

## Docs / specs
- `sdk-audit.yaml` — wire-format audit.
- `docs/specs/unified-wire-envelope.md` (resolves #30), `docs/specs/network-schema-sanitization.md` (resolves #40).
- Version-reference bumps (2.1.13, java8 backport pointers).