### PR TITLE
docs+ci: EdgeRUM conformance execution specs + ready-for-agent worker trigger

### DIFF
--- a/.github/workflows/claude-worker.yml
+++ b/.github/workflows/claude-worker.yml
@@ -1,6 +1,6 @@
 name: Claude Worker
 
-# Implements a ticket automatically when it is labeled "ready-to-work",
+# Implements a ticket automatically when it is labeled "ready-for-agent",
 # but only if none of its native GitHub blocking issues are still open.
 on:
   issues:
@@ -11,7 +11,7 @@ jobs:
   # /to-tickets). issue_dependencies_summary.blocked_by counts OPEN blockers only,
   # so > 0 means a blocker is still open and we must not run.
   gate:
-    if: github.event.label.name == 'ready-to-work'
+    if: github.event.label.name == 'ready-for-agent'
     runs-on: ubuntu-latest
     permissions:
       issues: read

--- a/docs/specs/anr-detection.md
+++ b/docs/specs/anr-detection.md
@@ -1,0 +1,137 @@
+# Android spec — ANR detection (feature gap)
+
+Resolves wayfinder ticket **#38** (feature-matrix `anr-detection: planned`, `sdk-audit.yaml:413`).
+Net-new datapoint — there is **no** ANR / watchdog / main-thread-block code in the SDK today
+(`sdk-audit.yaml:413`, grep-confirmed). Reference implementation:
+`edge_telemetry_ionic_angular_capacitor/.../com/nathanclaire/rum/AnrWatchdog.kt` — the only
+EdgeRUM SDK that ships Android ANR detection.
+
+Rides the unified envelope (**#30**, `docs/specs/unified-wire-envelope.md`) and reuses the
+durable-fatal persistence rail from the crash spec (**#39**, `docs/specs/retire-crash-path-b.md`).
+Both are fixed input.
+
+Plan-only. This is the implementation spec; no code is changed on this branch.
+
+## Problem
+
+ANRs (Application Not Responding — main thread blocked long enough that the framework would show
+the "app isn't responding" dialog) are a top user-facing quality signal and are entirely
+uninstrumented here. `web-vitals` is `na` (native), so ANR + frame-stats + app-start are the
+native performance story; frame-stats ships (#36), ANR does not.
+
+## Decisions (from prototype/grilling #38)
+
+The watchdog **loop mechanism is already prototyped** (the reference `AnrWatchdog`), so the open
+work was the four design forks below, not the loop shape.
+
+### 1. Mechanism — main-thread watchdog only
+
+A single daemon background thread posts a heartbeat `Runnable` to the main `Looper` and waits.
+If the main thread doesn't run the heartbeat within the threshold, it's blocked → capture + emit.
+This is the reference approach.
+
+- **Works on minSdk 24** (whole install base); no API-level gate.
+- Captures the hang **live**, with our own screen/session/user context at detection time.
+- **Rejected: `ApplicationExitInfo.REASON_ANR`** (API 30+, next-launch harvest of the system's
+  authoritative trace). Better fidelity (native frames, only fires on real system ANRs) but adds
+  a second source to dedup against, a next-launch harvest path, and covers only API 30+. Deferred
+  to fog (see map **Not yet specified**) as an *enrichment* over the watchdog, not a replacement.
+- **Accepted trade-off:** the watchdog reports "main thread blocked ≥ threshold," which the system
+  might not itself have declared an ANR (e.g. a slow device, a debugger pause). The 5s threshold
+  (§2) gates this; downstream can reconcile against `ApplicationExitInfo` later if the fog ticket
+  graduates.
+
+### 2. Threshold — fixed 5000 ms
+
+Matches Google's input-dispatch ANR line. This deliberately draws the boundary against
+**hang-detection** (map fog, the sibling feature), which owns the sub-5s "slow but not an ANR"
+band. Keeping ANR at exactly the system threshold means an `app.anr` event corresponds to what the
+platform itself would call an ANR.
+
+- Internal constant, **not** a public config flag (ponytail: no config for a value that won't
+  change). Upgrade path: promote to `TelemetryConfig` only if a consumer needs a different line.
+- Heartbeat interval = `threshold / 2`, floored at 500 ms (reference), so a real 5s hang is caught
+  in one scan.
+
+### 3. Capture — all-thread dump
+
+The event captures **every** thread's stack, main thread flagged. Main-thread-only (the reference)
+is blind to the most common ANR root cause: a **deadlock / lock contention**, where the blocked
+main thread's stack shows it *waiting* but the culprit is the background thread *holding* the lock.
+ANRs are rare, so the full `Thread.getAllStackTraces()` dump cost is negligible against its
+diagnostic value.
+
+### 4. Event identity — new `app.anr` event
+
+Distinct event name, **not** reused `app.crash`. An ANR is not a crash (with a watchdog the
+process usually survives), and dashboards want a separate **ANR-free rate** alongside crash-free
+rate. Emitted as a standard event through the same `EventAttributes` enrichment as everything else
+(#30), so it automatically carries `session.*` / `user.*` / `sdk.*`.
+
+Shape (D1 unprefixed keys, JSON-typed, consistent with #39):
+
+```
+event  app.anr
+  is_fatal      false        (watchdog fires; the process is not guaranteed dead)
+  handled       false        (auto-detected, not caught by app code — matches #39's handled=false for uncaught)
+attributes
+  anr.duration_ms   <int>    main thread blocked this long (SystemClock.uptimeMillis delta)
+  screen            <string> current screen at detection (getCurrentScreen(), Activity + Compose — same source as #36)
+  anr.threads       [ { name, state, main:bool, stack:"at a.b(f:1)\n..." }, ... ]   all threads, main flagged
+  session.*, user.* frozen at detection time (same freeze discipline as crash, audit #1)
+```
+
+### 5. Delivery — persist-then-batch on the durable-fatal rail (reuse #39)
+
+The system can kill the app **during** the ANR (after its own ~5s window), so an in-memory-only
+event would be lost with the unflushed batch. On detection the watchdog:
+
+1. **Synchronously writes** the `app.anr` record to `filesDir` (the eviction-exempt store #39
+   established — **not** `cacheDir`), then
+2. enqueues it to the normal batch.
+
+On next `initialize()` the existing #39 replay reads pending records, sends, and **deletes only
+after a 2xx**. `is_fatal:false` distinguishes it from a fatal crash record on the same rail. No new
+persistence code — this is the crash durable-fatal rail with an ANR record type.
+
+### 6. Sampling & dedup
+
+- **No sampling** — consistent with the SDK's effective 100%-capture posture; ANRs are rare.
+- **Intra-hang dedup:** after firing, the watchdog sleeps ≥ `threshold` before re-scanning
+  (reference), so one long hang = **one** `app.anr` event, not one per scan.
+- **No cross-session suppression.** Each distinct hang is worth counting for ANR-rate; grouping is
+  a downstream concern (fingerprint on the main-thread stack), not client-side drop.
+
+## Lifecycle
+
+- **Start** after `initialize()` completes (SDK ready).
+- **Foreground-only:** pause the watchdog on background, resume on foreground, via the
+  `ProcessLifecycleOwner` observer the SDK already runs (CLAUDE.md — lifecycle tracking). Avoids
+  waking a backgrounded/dozing device to post heartbeats; user-facing ANRs are foreground events.
+  (Background broadcast-receiver ANRs are out of scope for v1 — note.)
+- Daemon thread; `stop()` on process teardown / `resetForTesting()`.
+
+## Files (new + touched)
+
+| File | Change |
+|---|---|
+| `core/anr/AnrWatchdog.kt` | **New.** Port of the reference watchdog: heartbeat loop, 5s threshold, all-thread dump, intra-hang dedup. Emits an `app.anr` event via the enrichment path. |
+| `core/services/CrashReportingService.kt` (or a small `AnrService`) | Owns watchdog start/stop, wires foreground gating + the persist-then-batch rail (#39). |
+| `TelemetryManager.kt` | Start watchdog post-init; stop on teardown. |
+| `TelemetryConfig.kt` | No public flag (§2). |
+
+## Test plan
+
+- **Unit (Robolectric):** block the main `Looper` past 5s (a `Thread.sleep` posted to it) → exactly
+  one `app.anr` emitted, `anr.duration_ms ≥ 5000`, `anr.threads` contains a `main:true` entry, and
+  a record lands in `filesDir`. Unblock before 5s → **zero** events (no false positive).
+- **Intra-hang dedup:** a 12s block → exactly one event, not ~2.
+- **Lifecycle:** background → no heartbeats posted (spy the handler); foreground resumes.
+- **Delivery:** a persisted `app.anr` record replays on next `initialize()` and is deleted only
+  after a stubbed 2xx (shares #39's replay test harness).
+
+## Not a hub gap
+
+ANR is decided android-local (no hub ANR contract). The `app.anr` event name + attribute shape is
+proposed android-first; other SDKs conform if/when they add ANR. Flag the name to the hub for
+cross-SDK consistency, don't block on it.

--- a/docs/specs/bounded-buffers-eviction.md
+++ b/docs/specs/bounded-buffers-eviction.md
@@ -1,0 +1,155 @@
+# Android spec — bounded buffers & eviction policy
+
+Resolves wayfinder ticket **#33** (audit #8 + #14, hub decision **D9**). Evidence:
+`sdk-audit.yaml:299-321` + file:line refs below.
+
+Plan-only. This is the implementation spec; no code is changed on this branch.
+
+D9 (hub, `edge_rum_spec` #1) is taken as **given**: durable offline storage is a **200-envelope,
+drop-oldest** bounded buffer. This spec is the android *how* for that, plus the two other unbounded
+stores the audit found that D9 doesn't cover (the in-memory queue and the pre-init buffer).
+
+## Problem
+
+Three client-side stores accumulate telemetry. Two are unbounded — a long-offline or chatty session
+grows them without limit until OOM. One is already bounded and just needs confirming.
+
+| Store | Holds | Cap today | Evidence |
+|---|---|---|---|
+| Offline batch store | `TelemetryBatch` envelopes | **none** | `OfflineBatchStorage.kt:23-28`, `sdk-audit.yaml:311-313` |
+| In-memory `eventQueue` | `TelemetryEvent` | **none** | `ConcurrentLinkedQueue`, `sdk-audit.yaml:314` |
+| Pre-init buffer | `() -> Unit` closures | 50, FIFO | `TelemetryManager.kt:83,1053-1057` |
+
+Two defects beyond "no cap":
+
+1. **Non-atomic offline writes.** `storeBatch` / `removeBatch` do read-modify-write of the *whole*
+   batch list as one Gson blob in SharedPreferences (`OfflineBatchStorage.kt:23-46`). Two concurrent
+   stores race → last-write-wins silently drops a batch. `sdk-audit.yaml:312`.
+
+2. **O(n²) queue enqueue.** Any cap check on `ConcurrentLinkedQueue` via `.size` is O(n) — the class
+   walks the list to count. Checking size on every `offer` makes enqueue O(n²). The existing size
+   reads (`BatchProcessingService.kt:62,79,83`) already pay this; a naive cap would make it worse.
+
+## Decisions
+
+### 1. Offline batch store — 200 envelopes, drop-oldest, atomic (D9)
+
+Keep SharedPreferences; **do not** move to Room. Room is declared **runtime + ktx only**
+(`build.gradle.kts:123-124`) with **no `room-compiler` and no ksp/kapt plugin** — it is dead weight
+in the AAR, not a free installed dependency. Wiring it means adding a compiler dep + the ksp plugin +
+schema export: build machinery this ticket doesn't justify for a 200-item store that fills only while
+offline (low write frequency).
+
+Two fixes, both in `OfflineBatchStorage.kt`:
+
+- **Serialize all mutations with a `Mutex`.** `storeBatch` / `removeBatch` / eviction run under one
+  `kotlinx.coroutines.sync.Mutex.withLock`. Kills the read-modify-write race. (Class-scoped lock; a
+  single process, single prefs file — no cross-process contention to design for.)
+
+- **Cap at 200, drop-oldest on insert.** After appending, if `size > 200`, drop from the front
+  (`subList(size - 200, size)` — the list is append-ordered, so front = oldest). One line inside the
+  locked `storeBatch`.
+
+```kotlin
+// OfflineBatchStorage.kt
+private val mutex = Mutex()
+companion object { const val MAX_ENVELOPES = 200 }   // D9
+
+suspend fun storeBatch(batch: TelemetryBatch) = withContext(Dispatchers.IO) {
+    mutex.withLock {
+        val batches = getStoredBatchesLocked().toMutableList()
+        batches.add(batch)
+        val capped = if (batches.size > MAX_ENVELOPES)
+            batches.subList(batches.size - MAX_ENVELOPES, batches.size) else batches
+        prefs.edit().putString(PREFS_KEY, gson.toJson(capped)).apply()
+    }
+}
+```
+
+**Ceiling (named):** the whole ≤200-envelope blob is (de)serialized in memory and rewritten on every
+store — O(n), n≤200. Acceptable because stores happen only on send-failure (offline), i.e. at most
+one per flush cycle. Upgrade path if offline depth becomes real: finish the Room wiring, one
+`@Entity` per envelope, cap via `DELETE … ORDER BY seq LIMIT`. Tracked as fog, not this ticket.
+
+**Also drop the dead Room deps** (`build.gradle.kts:123-124`) — nothing in `src/main` references
+Room (`sdk-audit.yaml:307-308`), so the two `api(libs.androidx.room.*)` lines only bloat every
+consumer's app. Deletion over addition. (If the Room upgrade path above is later taken, they come
+back *with* the compiler + plugin — as a set, not half of one.)
+
+### 2. In-memory `eventQueue` — 500 events, drop-oldest, counted
+
+- **Cap = 500 events** — 10× the default `batchSize` (50, `TelemetryConfig.kt`). Absorbs a send-stall
+  or burst without OOM; well above one batch so normal flushing never trips it. Fixed constant, not
+  config — no evidence any consumer needs to tune it. Promote to `TelemetryConfig` only on request.
+
+- **Drop-oldest**, matching D9 and the pre-init buffer. Recent events are worth more (closer to a
+  crash / the current user state), so evict the front.
+
+- **Track size in an `AtomicInteger`**, not `.size` — increment on `offer`, decrement on `poll`.
+  Avoids the O(n²) enqueue. All enqueues go through one helper (mirror of the pre-init pattern at
+  `TelemetryManager.kt:1053-1057`):
+
+```kotlin
+private val queueCount = AtomicInteger(0)   // ponytail: authoritative count; ConcurrentLinkedQueue.size is O(n)
+
+private fun enqueueEvent(ev: TelemetryEvent) {
+    if (queueCount.get() >= MAX_QUEUED_EVENTS) {   // 500
+        if (eventQueue.poll() != null) queueCount.decrementAndGet()   // drop-oldest
+    }
+    eventQueue.offer(ev); queueCount.incrementAndGet()
+}
+```
+
+Every `eventQueue.poll()` on the drain paths (`BatchProcessingService.kt:89,175`) must
+`queueCount.decrementAndGet()` to keep the counter honest. Since those live in the service and the
+counter in the manager, the drain either moves into a helper the service calls back into, or the
+counter is passed in — same split already used for the flush callback in spec #32. **Simplest:** make
+the count the service's own field (the service owns every enqueue/poll site) and expose it; the
+pre-init buffer stays the manager's.
+
+### 3. Pre-init buffer — confirmed, no change
+
+Already 50, FIFO drop-oldest (`TelemetryManager.kt:1051-1057`). Correct and already aligned with
+drop-oldest. It drains once at init and never refills, so 50 is ample. **Decision: keep as-is.**
+
+### 4. Replay throttling — bounded, oldest-first, stop-on-failure
+
+A device offline long enough to fill 200 envelopes must not, on reconnect, fire 200 back-to-back
+POSTs. Today `sendStoredBatches` loops over *all* stored batches with no delay and no early exit
+(`BatchProcessingService.kt:118-133`).
+
+- **Drain at most `REPLAY_BATCH_LIMIT = 10` oldest envelopes per flush cycle**, oldest-first. The
+  30 s flush timer (spec #32) paces the rest — 200 envelopes clear in ~20 cycles, not one burst. No
+  new scheduler; reuse the flush tick.
+
+- **Stop on the first failure** in a cycle. A 4xx/5xx/network error means the collector isn't ready
+  for more; the remaining stored envelopes wait for the next tick. (Current code logs and keeps
+  going — wasteful when the endpoint is down.)
+
+- **Delete `restoreOfflineBatches`** (`BatchProcessingService.kt:151-166`). It un-batches stored
+  envelopes back into the in-memory queue, which then re-batches them — pointless double handling,
+  and now actively harmful: it would push events straight into the newly-capped 500-event queue and
+  trigger drop-oldest eviction of live events. Replay goes offline-store → network directly, never
+  back through the queue.
+
+## Migration & compatibility
+
+- All three changes are **client-internal** — no wire-format impact, independent of the envelope
+  cutover (#30). Envelope *shape* is D1/#30's; this ticket only bounds *how many* are buffered.
+- Existing on-device offline blobs deserialize unchanged; the 200-cap applies from the next store on.
+- Dropping the Room deps is source-compatible (nothing imports Room) and shrinks the AAR.
+
+## Test plan
+
+- `OfflineBatchStorage`: store 201 envelopes → assert size == 200 and the *first* is gone
+  (drop-oldest). Concurrent `storeBatch` from two coroutines → assert no batch lost (atomicity).
+- `eventQueue`: enqueue 501 events → assert size == 500, oldest dropped, `queueCount` == 500.
+- Replay: seed 25 stored envelopes, one flush cycle → assert ≤10 sent; inject a failure at #3 →
+  assert send stops and 23 remain.
+- Pre-init: unchanged — existing FIFO-eviction test still passes.
+
+## Flags to hub
+
+- **D9 names the offline (durable) buffer at 200 envelopes but is silent on the live in-memory
+  queue.** The 500-event queue cap is decided android-local here. If other SDKs also carry an
+  in-memory queue, the hub may want a common guidance number — raise on `edge_rum_spec`.

--- a/docs/specs/broken-timed-flush.md
+++ b/docs/specs/broken-timed-flush.md
@@ -1,0 +1,147 @@
+# Android spec — fix the broken timed flush
+
+Resolves wayfinder ticket **#32** (audit #7). Independent — no hub decision, no envelope
+coupling. Evidence: `sdk-audit.yaml:280-286` + file:line refs below.
+
+Plan-only. This is the implementation spec; no code is changed on this branch.
+
+## Problem
+
+`config.flushIntervalMs` (default 30 000 ms, `core/TelemetryConfig.kt:7`) schedules a periodic
+flush, but the Runnable body is **empty** — a lone comment, no call:
+
+```kotlin
+// BatchProcessingService.kt:197-203
+flushTimer?.scheduleWithFixedDelay({
+    try {
+        // Timer will trigger batch send check in TelemetryManager   ← never wired
+    } catch (e: Exception) { Log.e(TAG, "Error in flush timer", e) }
+}, config.flushIntervalMs, config.flushIntervalMs, TimeUnit.MILLISECONDS)
+```
+
+So the timer fires every 30 s and does nothing. Batches actually leave only on two triggers:
+
+- **queue-size threshold** — `maybeSendBatch()` (`TelemetryManager.kt:637-646`) sends when
+  `queueSize >= config.batchSize` (default 50).
+- **lifecycle transitions** — `onStop` flushes to **offline storage** (SharedPreferences), *not*
+  the network (`TelemetryManager.kt:431-447`; `sdk-audit.yaml:288`).
+
+**Impact:** a low-activity session (< 50 events, app stays foregrounded) holds all telemetry
+client-side **indefinitely**. The 30 s guarantee the config advertises does not exist.
+
+### Why the obvious fix is wrong
+
+You cannot just drop `maybeSendBatch()` into the Runnable. That call is **size-gated** — below
+`batchSize` it no-ops. The timer's entire job is to flush **partial** batches, i.e. exactly the
+case `maybeSendBatch()` skips. The timed path must force-send.
+
+### Why it can't be fixed inside the service alone
+
+`BatchProcessingService` holds no reference to the event queue or the current location — both live
+in `TelemetryManager`, passed *into* `sendBatch(...)` per call (`TelemetryManager.kt:657-662`).
+The timer thread inside the service has nothing to flush. The fix has to bridge that gap.
+
+## Decision
+
+**Inject a flush callback from `TelemetryManager` into the timer.** The service owns the schedule;
+the manager owns the queue + location. Callback keeps that split intact — no queue reference leaks
+into the service.
+
+### 1. `startFlushTimer` takes an `onFlush` lambda
+
+```kotlin
+// BatchProcessingService
+private var onFlush: (() -> Unit)? = null
+
+fun initialize(onFlush: () -> Unit) {
+    this.onFlush = onFlush
+    startFlushTimer()
+}
+
+fun startFlushTimer() {
+    flushTimer = Executors.newSingleThreadScheduledExecutor()
+    flushTimer?.scheduleWithFixedDelay({
+        try {
+            onFlush?.invoke()
+        } catch (e: Exception) {
+            Log.e(TAG, "Error in flush timer", e)
+        }
+    }, config.flushIntervalMs, config.flushIntervalMs, TimeUnit.MILLISECONDS)
+}
+```
+
+`resumeFlushTimer()` already calls `startFlushTimer()`, so storing `onFlush` as a field (not a
+`startFlushTimer` param) keeps resume working after a stop without re-threading the lambda.
+
+### 2. `TelemetryManager` supplies the force-flush
+
+The manager already has a force-send path — `sendBatch(forceSend = true)` (`:650-663`), which
+resolves location and delegates to `batchProcessingService.sendBatch(...)`. The timed flush is that
+path launched on the IO scope:
+
+```kotlin
+// Step 8, TelemetryManager.kt:288-291 — was batchProcessingService.initialize()
+batchProcessingService.initialize(onFlush = {
+    scope.launch { sendBatch(forceSend = true) }
+})
+```
+
+That's the two-line fix in practice: one param added to `initialize`, one lambda passed.
+
+### 3. Empty-queue is already safe — no extra guard
+
+`sendBatch(forceSend = true, ...)` polls the queue into `eventsToSend` and returns early when it's
+empty (`BatchProcessingService.kt:93`). So a timer tick on an idle session builds no batch and
+POSTs nothing. **No empty/heartbeat requests.** No new guard needed.
+
+### 4. `flushIntervalMs` semantics — unchanged
+
+`scheduleWithFixedDelay(initialDelay = flushIntervalMs, period = flushIntervalMs)` stays as-is.
+`fixedDelay` (gap *after* completion) over `fixedRate` is correct here: a slow/blocked send must
+not let ticks pile up. First flush at 30 s, not at t=0 — matches the current schedule and avoids a
+startup send before any events exist. Concurrency with a size-triggered send is safe:
+`ConcurrentLinkedQueue.poll()` hands each event to exactly one caller, so the two paths can't
+double-send an event.
+
+## Failing test
+
+`BatchProcessingServiceTest` — the timer must flush a **partial** (sub-`batchSize`) queue. Fails
+today (empty Runnable → `sendBatch` never called); passes after the fix.
+
+```kotlin
+@Test
+fun `timed flush force-sends a partial batch`() = runTest {
+    // batchSize = 50, flushIntervalMs small for the test (e.g. 100ms)
+    val queue = ConcurrentLinkedQueue<TelemetryEvent>().apply { offer(anEvent()) } // 1 < 50
+    coEvery { httpClient.sendBatch(any()) } returns Result.success(Unit)
+    service.setIdsInitialized(true)
+
+    service.initialize(onFlush = { scope.launch { service.sendBatch(queue, forceSend = true) } })
+
+    // advance past one interval
+    coVerify(timeout = 1000) { httpClient.sendBatch(match { it.batchSize == 1 }) }
+}
+
+@Test
+fun `timed flush on an empty queue sends nothing`() = runTest {
+    service.setIdsInitialized(true)
+    service.initialize(onFlush = { scope.launch { service.sendBatch(ConcurrentLinkedQueue(), forceSend = true) } })
+    advanceTimeBy(interval * 2)
+    coVerify(exactly = 0) { httpClient.sendBatch(any()) }
+}
+```
+
+Real-timer scheduling is awkward under `runTest`; the pragmatic version drives the interval with a
+short real `flushIntervalMs` + a Robolectric idle, or refactors the schedule behind an injectable
+executor. Either is fine — the assertion (`httpClient.sendBatch` called with a sub-threshold batch)
+is what must hold.
+
+## Files touched (execution, downstream)
+
+| File | Change |
+|---|---|
+| `core/services/BatchProcessingService.kt` | `initialize(onFlush)`; store `onFlush`; Runnable calls `onFlush?.invoke()` |
+| `core/TelemetryManager.kt` | pass `onFlush = { scope.launch { sendBatch(forceSend = true) } }` at step 8 (`:289-290`) |
+| `core/services/BatchProcessingServiceTest.kt` | the two tests above |
+
+No config change, no wire-format change, no interaction with the #30 envelope work.

--- a/docs/specs/ci-conformance.md
+++ b/docs/specs/ci-conformance.md
@@ -1,0 +1,122 @@
+# Android spec: CI conformance — trigger, test/lint gates, toolchain pin
+
+**Map ticket:** [#31](https://github.com/NCG-Africa/edge_telemetry_android/issues/31) · **Audit:** #4 (`sdk-audit.yaml:446-459`) · **Status:** plan-only (spec, not merged)
+
+## Problem
+
+`.github/workflows/gradle.yml` ("Build Library") triggers on branch `main`, but the active
+default branch is `master`. **CI effectively never runs.** On top of the dead trigger it is
+build-only (`./gradlew clean assembleRelease -x lint`) — no unit tests, lint explicitly skipped —
+and there is no single pinned build JDK across GitHub Actions (JDK 17) and JitPack (mainline: none;
+java8 branch: `openjdk11`). The java8 branch's `jitpack.yml` also hardcodes `-Pversion=1.2.3-java8`,
+two patches behind that branch's own `sdkVersion = "1.2.5-java8"`.
+
+## Evidence
+
+| Fact | Source |
+|---|---|
+| Trigger is `main`, default branch is `master` | `.github/workflows/gradle.yml:4,8`; `git symbolic-ref` → master |
+| `origin/main` is a stale orphan (`a20d9ab Update README.md`), not an ancestor of master | `git log origin/main` vs `origin/master` |
+| Build-only, lint skipped | `.github/workflows/gradle.yml` last step: `assembleRelease -x lint` |
+| 28 unit-test files exist but never run in CI | `telemetry_library/src/test/**/*.kt` |
+| `lint { abortOnError = false }` — lint never fails the build | `telemetry_library/build.gradle.kts:68` |
+| Compile target Java 11, but no Gradle **toolchain** declared (relies on launcher JDK) | `build.gradle.kts:48-56` |
+| No `jitpack.yml` on master → JitPack picks an arbitrary default JDK | repo root (absent) |
+| java8 `jitpack.yml` pins `-Pversion=1.2.3-java8`; branch `sdkVersion = "1.2.5-java8"` | `java8-legacy-1.2.5:jitpack.yml`; `:build.gradle.kts:13` |
+| `detekt` + `metalava` plugins wired with baselines, also unrun in CI | `build.gradle.kts:7-8,15-24`; `detekt-baseline.xml`, `api/current.api` present |
+
+## Decisions
+
+### D-31.1 — Trigger: `master` only, drop `main`
+
+Point push + PR triggers at `master`. **Drop `main` entirely** — it is a stale orphan (one
+`Update README.md` commit, not on master's history), not a maintained release line. Keeping it in
+the trigger list only re-creates the "which branch is live?" ambiguity that caused this bug.
+
+- If the orphan README edit is worth keeping, cherry-pick it onto master (separate, trivial).
+- **Deleting the `origin/main` branch** is recommended but is an ops action, out of this plan-only
+  ticket. Retargeting the trigger fixes CI regardless of whether the branch is deleted.
+
+### D-31.2 — Add unit-test + lint gates (lint needs a baseline to actually gate)
+
+Single job runs, in order: `testDebugUnitTest`, `lintDebug`, `assembleRelease` (drop `-x lint`).
+
+`lintDebug` alone is a **no-op** today because `build.gradle.kts:68` sets `abortOnError = false`.
+To make it a real gate without a red-on-day-one avalanche of pre-existing warnings:
+
+1. Generate a lint baseline once — `lint { baseline = file("lint-baseline.xml") }` + a baseline run —
+   grandfathering current violations.
+2. Set `abortOnError = true` so **new** violations fail CI; keep `warningsAsErrors = false`.
+
+Both are one-line `build.gradle.kts` edits, executed downstream (this ticket only specifies them).
+`testDebugUnitTest` needs no such guard — 28 test files already exist; if any currently fail, that
+is a genuine red the gate is meant to catch.
+
+> Publish stays out of CI — JitPack builds on tag, not on push. No artifact/publish step added.
+
+### D-31.3 — Pin the toolchain: launcher JDK 17 everywhere, compile target 11 via Gradle toolchain
+
+"One toolchain" is two distinct knobs that were being conflated:
+
+- **Launcher JDK** (runs Gradle/AGP): pin to **17** everywhere. Actions already uses 17. Add a
+  `jitpack.yml` on **master** pinning `openjdk17` so JitPack stops defaulting to an arbitrary JDK —
+  this is the only mainline reproducibility gap. AGP 8.7 requires JDK 17 to run.
+- **Compile target** (bytecode level): pin to **11** by declaring a Gradle Java toolchain in
+  `build.gradle.kts`, replacing the loose `sourceCompatibility`/`targetCompatibility`/`jvmTarget`
+  trio with one source of truth:
+  ```kotlin
+  kotlin { jvmToolchain(11) }   // or java { toolchain { languageVersion = JavaLanguageVersion.of(11) } }
+  ```
+  This makes the 11 target independent of the 17 launcher, so "Actions JDK 17 vs compile 11" stops
+  reading as drift — it's launcher vs target, both now explicit.
+
+The **java8 backport is a separate product** (Java 8 bytecode) and legitimately keeps its own
+launcher/target; it is not folded into the mainline pin. Its only defect is D-31.4.
+
+### D-31.4 — java8 `jitpack.yml`: delete the `-Pversion` override, don't chase it
+
+The `-Pversion=1.2.3-java8` flag is both **stale and redundant**: `build.gradle.kts` already sets
+`version = sdkVersion` (`1.2.5-java8`). Hardcoding the version in `jitpack.yml` guarantees drift on
+every release. **Delete `-Pversion` (and `-Pgroup`, also already set in the build)** so the artifact
+coordinates follow the build's own `group`/`sdkVersion`. This removes the drift class permanently
+rather than bumping 1.2.3→1.2.5 and re-drifting next release. Applies to branch `java8-legacy-1.2.5`
+(and any live java8 branch); mainline needs no such edit.
+
+## Target workflow (`.github/workflows/gradle.yml`)
+
+```yaml
+name: Build Library
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17          # launcher; compile target is pinned to 11 by the Gradle toolchain
+          cache: gradle
+      - run: chmod +x gradlew
+      - name: Test + lint + build
+        run: ./gradlew clean testDebugUnitTest lintDebug assembleRelease --stacktrace
+```
+
+`detekt`/`metalava` are wired with baselines and also unrun in CI. Adding `detektMain` (baseline
+exists → cheap) and a `metalavaCheckCompatibility` API-lock step is a reasonable follow-up, but is
+**out of scope for #31** (audit #4 named tests + lint only). Flag as fog, don't gold-plate here.
+
+## Downstream execution checklist (not done here — plan-only)
+
+1. `gradle.yml`: retarget `main`→`master`, drop `-x lint`, add `testDebugUnitTest lintDebug`.
+2. `build.gradle.kts`: add `kotlin { jvmToolchain(11) }`; add `lint { baseline = ...; abortOnError = true }` + generate `lint-baseline.xml`.
+3. New `jitpack.yml` on master pinning `openjdk17`.
+4. java8 branch `jitpack.yml`: remove `-Pversion`/`-Pgroup` overrides.
+5. (Ops) delete stale `origin/main`, optional cherry-pick of its README edit.

--- a/docs/specs/dead-code-removal.md
+++ b/docs/specs/dead-code-removal.md
@@ -1,0 +1,152 @@
+# Android spec: dead-code removal (audit #12, D14)
+
+**Ticket:** [#37](https://github.com/NCG-Africa/edge_telemetry_android/issues/37) · **Map:** [#29](https://github.com/NCG-Africa/edge_telemetry_android/issues/29)
+**Type:** research (AFK) · **Status:** spec, plan-only (no merged code)
+
+## Problem
+
+`sdk-audit.yaml:322-347,435-438` (D14) lists code that is compiled and shipped in the
+AAR but never reaches the live wire. It is inert today, but an external reviewer or
+security audit reads it as live surface — `IpLocationProvider` looks like the SDK phones
+`ipinfo.io`; `EdgeTelemetryInterceptor` looks like it leaks full URLs. Deleting it shrinks
+the audit surface to what actually runs.
+
+This spec decides the **delete list**, the **public-API removal story** (`enableLocationTracking`,
+`testConnectivity`), and the **sequencing** against other map tickets. Every claim below was
+verified against source, not taken from the audit — two audit items needed correction (see
+[Corrections](#corrections-to-the-audit)).
+
+## Delete list (verified)
+
+Each item: what to remove, the evidence it is dead, and its dependency.
+
+### A. Location stack — **independent, delete now**
+
+Provider code is never instantiated: `locationProvider` is declared `= null`
+(`TelemetryManager.kt:111`) and never assigned, so the guarded reads at
+`TelemetryManager.kt:639-640,651-652` always fall through to `currentLocation` (also never
+set). `enableLocationTracking` is a no-op flag.
+
+- **Delete** `core/location/IpLocationProvider.kt` (131 lines).
+- **Delete** `core/location/LocationProvider.kt` (9-line interface) — only implementor is the file above; only-other-referent is the field below.
+- **Delete** field `locationProvider` (`TelemetryManager.kt:111`) + imports (`:21-22`).
+- **Delete** field `currentLocation` (`TelemetryManager.kt:112`) — never assigned.
+- **Simplify** the two `location` blocks (`TelemetryManager.kt:639-652`): with the provider gone the value is always `null`. Coordinate with **#30**, which already removes the `location` field from the wire (`TelemetryDataOut`) — once that lands, the local `location` variable feeds nothing and the whole block is deleted, not just simplified.
+- **Remove** config field `enableLocationTracking` (`TelemetryConfig.kt:20`) — see [Public API](#public-api-removal).
+- **Delete tests** `IpLocationProviderTest.kt` and `LocationIntegrationTest.kt` (435 lines) — both exercise only this dead path.
+- **Strip** the `enableLocationTracking = false,` line from 8 service/integration test configs (`UserProfileServiceTest.kt:36`, `EventTrackingServiceTest.kt:42`, `SessionServiceTest.kt:38`, `TelemetryManagerIntegrationTest.kt:42,481`, `EventIntegrationTest.kt:37`, `CrashReportingServiceTest.kt:52`, `BatchProcessingServiceTest.kt:39`) — mechanical, follows from removing the config field.
+
+### B. `JsonEventTracker` — **independent, delete now**
+
+Field `jsonEventTracker` is `= null` (`TelemetryManager.kt:108`), never assigned. Its only
+call site, `jsonEventTracker?.testConnectivity()` (`TelemetryManager.kt:1026`), is a
+permanent no-op that always logs "Event tracker not initialized". The class's send methods
+are log-only stubs (audit #12).
+
+- **Delete** `core/events/JsonEventTracker.kt` (327 lines).
+- **Delete** field `jsonEventTracker` + import (`TelemetryManager.kt:108,19`).
+- **Delete** public method `testConnectivity()` (`TelemetryManager.kt:1024-1028`) — see [Public API](#public-api-removal).
+- The other referent, `EdgeTelemetryInterceptor` (constructor param, `:16`), dies with item D.
+
+### C. `LegacyPerformanceTracker` — **independent, delete now**
+
+`PerformanceTrackerFactory.createPerformanceTracker` unconditionally returns
+`ModernPerformanceTracker` (`PerformanceTracker.kt:24-27`). `LegacyPerformanceTrackerWrapper`
+(`:64-85`) is the only referent of `LegacyPerformanceTracker` and is itself never
+instantiated. This is why frame sampling (the 10% `SAMPLING_RATE`) is effectively off — the
+only sampler lives here (audit #12/#13).
+
+- **Delete** `core/LegacyPerformanceTracker.kt` (291 lines).
+- **Delete** class `LegacyPerformanceTrackerWrapper` (`PerformanceTracker.kt:61-85`).
+- Cross-link **#36** (frame-metrics windowing) retired per-frame sampling anyway; this removal is the code-level tail of that decision and does not depend on it.
+
+### D. `EdgeTelemetryInterceptor` — **blocked on #40, delete after**
+
+Zero referents anywhere except its own file (grep confirmed). Public but unwired; sends the
+**full URL incl. query** into `http.url` and breadcrumbs (`EdgeTelemetryInterceptor.kt:28,98`),
+which is exactly the leak **#40** (unify network schema + URL sanitization, audit #2/#6) is
+chartered to fix. #40 owns the interceptor consolidation and the sanitization contract.
+
+- **Delete** `core/http/EdgeTelemetryInterceptor.kt` (130 lines) **as part of #40**, not here — removing it in isolation and then reworking network in #40 touches the same seam twice. Removing it also removes the last consumer of `JsonEventTracker` (item B), but B does not need to wait on D.
+
+### E. `TelemetryPayload` wrapper — **independent, delete now**
+
+The live serializer builds `TelemetryDataOut` and sends it directly — `"Send TelemetryDataOut
+directly (no wrapper)"` (`TelemetryHttpClient.kt:165`). The outer `TelemetryPayload`
+`{timestamp, device_id, data}` wrapper has **zero live constructors**; its import at
+`TelemetryHttpClient.kt:10` is a dead import.
+
+- **Delete** `data class TelemetryPayload` (`core/models/TelemetryBatch.kt:7-19`).
+- **Delete** the dead import (`TelemetryHttpClient.kt:10`).
+- **Keep** `TelemetryDataOut` + `TelemetryEventOut` (same file) — **live**, owned by **#30** (rename `type` → `telemetry_batch`, drop `device_id`/`location`). Do not touch them here.
+
+### F. `EventBatchPayload` / `createEventBatchPayload` — **independent, delete now**
+
+`FlutterPayloadFactory.createEventBatchPayload` (`FlutterCompatiblePayload.kt:152`) has **no
+production callers** — the only callers are in the dead `LocationIntegrationTest.kt` (9
+sites), which item A already deletes.
+
+- **Delete** `data class EventBatchPayload` (`:36`) + `createEventBatchPayload` (`:152-…`).
+- Coordinate with **#30**, which already edits this file (deletes `CrashBatchEnvelope` +
+  `createCrashBatchEnvelope`). Same-file, independent edits; land together with #30's
+  serializer work to avoid a second pass over `FlutterCompatiblePayload.kt`.
+
+### G. Room dependency — **owned by #33, not this ticket**
+
+Zero source usage of `androidx.room`, `@Entity`, `@Dao`, or `RoomDatabase`; declared as
+`api(libs.androidx.room.runtime)` + `api(libs.androidx.room.ktx)` (`build.gradle.kts:123-124`),
+runtime-only, no compiler/ksp. **Already decided in closed [#33](https://github.com/NCG-Africa/edge_telemetry_android/issues/33)** ("dead Room deps … dropped"). Listed here only for
+completeness — do **not** re-own; it lands with #33's execution.
+
+## Public API removal
+
+Two removals touch the published surface. Both are safe to hard-remove — the SDK is
+pre-1.0, `2.x`, distributed via JitPack; there is no compatibility promise, and both members
+are functionally inert so no consumer relies on their behaviour.
+
+| Member | Decision |
+|---|---|
+| `TelemetryConfig.enableLocationTracking` | **Remove** the field. It gates only dead code — no location is ever collected regardless of value. No deprecation cycle: keeping a deprecated no-op flag preserves the exact "SDK does geo" audit signal we are deleting. Consumers passing it get a compile error naming the removed param — the clearest possible signal, resolved by deleting one argument. |
+| `TelemetryManager.testConnectivity()` | **Remove** the method. It is a debug helper that always logs "not initialized" and does nothing. Nothing wires it up. |
+
+**No dual-write, no marker, no runtime flag.** These are compile-time source removals.
+
+## Corrections to the audit
+
+Verification changed two audit claims — recorded so downstream execution trusts this list,
+not the raw audit:
+
+1. **`TelemetryPayload` dead, but `TelemetryDataOut`/`TelemetryEventOut` are LIVE.** The
+   audit lumps them; #30 correctly treats `TelemetryDataOut` as the live serializer. Only the
+   unused `TelemetryPayload` wrapper + its dead import are removable here (item E).
+2. **`enableLocationTracking` reads are guarded but the guard never fires** — the flag is not
+   just unused, its `true` branch is unreachable because `locationProvider` is permanently
+   null. Removal is behaviour-preserving.
+
+## Sequencing summary
+
+| Item | Depends on | When |
+|---|---|---|
+| A. Location stack | — (coordinate #30 wire-field) | now |
+| B. `JsonEventTracker` | — | now |
+| C. `LegacyPerformanceTracker` | — | now |
+| E. `TelemetryPayload` wrapper | — | now |
+| F. `EventBatchPayload` | — (land with #30's same-file edits) | now |
+| D. `EdgeTelemetryInterceptor` | **#40** | after #40 |
+| G. Room deps | **#33** (already decided) | with #33 |
+
+Net removal: **~890 lines of production Kotlin** + 2 dead test files (~600 lines) + 1 config
+flag + 1 public method, in one independent pass (items A/B/C/E/F) plus two follow-ons that
+ride existing tickets (D→#40, G→#33).
+
+## Verification for execution (non-negotiable)
+
+After deletion, the build must prove nothing live depended on the removed code:
+
+```bash
+./gradlew :telemetry_library:testDebugUnitTest :telemetry_library:assembleRelease
+```
+
+Both must pass with **zero** references to the deleted symbols remaining (grep the tree for
+each name). The compile step is the check — dead code that compiles-clean after removal was
+genuinely dead.

--- a/docs/specs/distributed-trace-span.md
+++ b/docs/specs/distributed-trace-span.md
@@ -1,0 +1,220 @@
+# Android spec — distributed trace/span contract (android-first, new)
+
+Resolves wayfinder ticket **#43**. **Net-new datapoint** — no trace/span code exists today
+(`sdk-audit.yaml` has no trace/span entries). The contract is **decided android-first**; other SDKs
+and the backend conform (per the map destination). Rides the unified envelope (#30), reuses the
+SecureRandom id machinery of #34, and its propagation rides the network interceptor owned by #40.
+
+Plan-only. This is the implementation spec; no code is changed on this branch.
+
+## Goal
+
+End-to-end visibility: an **app action → the network calls it triggers → backend spans** stitched
+into one trace. The app action is a user interaction (#42) or a screen entry; each network call is a
+child; the backend continues the same trace because the SDK injects a standard `traceparent` header.
+
+## Decisions
+
+Three forks were the human's call (grilling #43): **(a)** ID format = **W3C traceparent**;
+**(b)** a root span opens on a **user-interaction, else a screen**; **(c)** sampling = **100% by
+default, configurable**. The rest follows.
+
+### 1. IDs — W3C traceparent, not the `<kind>_..._android` family
+
+Trace/span identity is **W3C Trace Context**, because propagation only buys backend correlation if
+the wire header is the ubiquitous standard any OTel-compatible collector already reads:
+
+- **trace.id** — 32 lowercase hex (128-bit), 16 random bytes from `SecureRandom`.
+- **span.id** — 16 lowercase hex (64-bit), 8 random bytes.
+- **`traceparent` header** — `00-<trace.id>-<span.id>-<flags>`; version `00`, `flags = 01` (sampled).
+  We only ever inject when sampled, so `flags` is always `01` in v1 (see §6).
+
+These are **separate** from the `<kind>_<epochMs>_<16hex>_android` device/session/user join keys (#34):
+those stay opaque app-identity keys; trace/span ids must be W3C-shaped to interoperate. `IdGenerator`
+gains raw-hex helpers (`traceId()` = 32 hex, `spanId()` = 16 hex) reusing its existing `SecureRandom`.
+
+### 2. Spans are attributes on existing events — no separate span emission
+
+We do **not** emit span-start / span-end objects or a new event type. A span is expressed as three
+attributes on the event that already marks the work:
+
+| Attribute | On | Value |
+|---|---|---|
+| `trace.id` | every trace-participating event | 32 hex, same across the whole trace |
+| `span.id` | every trace-participating event | 16 hex, this event's span |
+| `parent.span.id` | child spans only (**omitted** on the root) | 16 hex, the parent's `span.id` |
+
+The **root span** rides the triggering `ui.interaction` (#42) or `navigation` event. Each network
+**child span** rides its `http.request` event (#40). The backend reconstructs the tree from these
+attributes plus the `traceparent` it received. No new machinery — reuses #30 enrichment, #42, #40.
+
+### 3. Root span lifecycle
+
+A single process-global "current root" holds the active trace. `TraceManager` (new,
+`core/trace/TraceManager.kt`):
+
+- **User-interaction → always a new root.** The #42 observer calls `onInteraction()`; it rolls
+  sampling, mints `trace.id` + a root `span.id`, replaces the current root, and returns the two attrs
+  to stamp on the `ui.interaction` event (no `parent.span.id`).
+- **Navigation → child if it followed an interaction, else a new root.** The screen tracker calls
+  `onNavigation()`. Within `ROOT_LINK_WINDOW_MS` (1000 ms) of the current root's open, the navigation
+  is treated as **caused by** that interaction (tap → navigate): it gets a child `span.id` under the
+  current root. Otherwise (cold start, deep link, programmatic nav) it opens its **own** root. Either
+  way the current root pointer is what later calls parent to.
+- **Background → cleared.** The already-wired `ProcessLifecycleOwner` `onStop` calls `onBackground()`,
+  nulling the current root so a background sync fired after the user leaves does not attach to a stale
+  tap's trace.
+
+<!-- ceiling: current root is a single process-global AtomicReference, not per-coroutine context.
+     A call fired from a stale foreground screen can attach to the wrong root. Accurate parenting needs
+     coroutine/thread context propagation — deferred to fog. Fine for the tap→calls 95% case. -->
+
+### 4. Child spans — network calls
+
+The interceptor (#40) per outgoing request calls `TraceManager.onNetworkCall()`:
+
+- If a **sampled** current root exists → mint a child `span.id`, inject
+  `traceparent: 00-<trace.id>-<childSpanId>-01` into the request headers, and return
+  `{trace.id, span.id=childSpanId, parent.span.id=rootSpanId}` for the interceptor to merge into the
+  `http.request` event.
+- If no active root (e.g. background call after §3 clear) → return null: the call emits `http.request`
+  with **no** trace attrs and **no** header, exactly as #40 already does. We do not manufacture a root
+  for every stray call — a call with no app-action parent is not part of an app-action trace.
+- If the request already carries a `traceparent` (an app set one) → **do not overwrite**; still stamp
+  our attrs from the header we would have used only when we own it. v1: skip injection when present.
+
+Duration is the request duration #40 already measures; the `http.request` event *is* the child span —
+no separate close.
+
+### 5. Propagation — `traceparent` only
+
+Inject `traceparent`; **no `tracestate`** in v1 (we carry no vendor trace-state; YAGNI). This lives in
+the #40 interceptor, before `chain.proceed()` for the header and after the response for the event
+attrs. #43 owns the trace additions to that interceptor; #40 owns the `http.*` re-keying.
+
+### 6. Sampling — head-based, `traceSampleRate` default 1.0
+
+Decided **once, at root-span open**. `TelemetryConfig` gains `traceSampleRate: Double = 1.0`
+(validated `0.0..1.0`). `onInteraction()` / new-root `onNavigation()` roll `SecureRandom.nextDouble()
+< traceSampleRate`; the boolean is stored on the root and **inherited** by every child. Unsampled root
+→ `TraceManager` returns null everywhere for that trace: no attrs, no header, no trace on our side.
+
+<!-- ceiling: not W3C-strict — an unsampled trace is dropped, not propagated with flags=00. Tail /
+     deferred sampling and sampled-out context propagation are fog, graduate if the backend needs them. -->
+
+## Prototype — the lifecycle model to react to
+
+```kotlin
+// core/trace/TraceManager.kt  — NEW. The whole contract is this one holder + three call sites.
+data class TraceContext(val traceId: String, val spanId: String, val sampled: Boolean, val startedAtMs: Long)
+
+object TraceManager {
+    private val current = AtomicReference<TraceContext?>(null)
+    @Volatile var traceSampleRate = 1.0          // set from TelemetryConfig
+    private const val ROOT_LINK_WINDOW_MS = 1000L
+
+    /** #42 interaction observer. Always a fresh root. → attrs for the ui.interaction event, or null (unsampled). */
+    fun onInteraction(nowMs: Long): Map<String, Any>? {
+        val sampled = SecureRandom().nextDouble() < traceSampleRate
+        val ctx = TraceContext(IdGenerator.traceId(), IdGenerator.spanId(), sampled, nowMs)
+        current.set(if (sampled) ctx else null)
+        return if (sampled) mapOf("trace.id" to ctx.traceId, "span.id" to ctx.spanId) else null
+    }
+
+    /** Screen tracker. Child of the current root if it just opened (tap→nav), else a new root. */
+    fun onNavigation(nowMs: Long): Map<String, Any>? {
+        val root = current.get()
+        if (root != null && root.sampled && nowMs - root.startedAtMs <= ROOT_LINK_WINDOW_MS) {
+            val childId = IdGenerator.spanId()
+            return mapOf("trace.id" to root.traceId, "span.id" to childId, "parent.span.id" to root.spanId)
+        }
+        return onInteraction(nowMs)   // no recent root → this nav IS the root
+    }
+
+    /** #40 interceptor, per request. → (headerValue, event attrs) or null when there's no sampled root. */
+    fun onNetworkCall(): Pair<String, Map<String, Any>>? {
+        val root = current.get()?.takeIf { it.sampled } ?: return null
+        val childId = IdGenerator.spanId()
+        val header = "00-${root.traceId}-$childId-01"
+        return header to mapOf("trace.id" to root.traceId, "span.id" to childId, "parent.span.id" to root.spanId)
+    }
+
+    /** ProcessLifecycleOwner onStop (already wired). */
+    fun onBackground() = current.set(null)
+}
+```
+
+Resulting tree for a tap that navigates and fires two calls (flat, two-level):
+
+```
+ui.interaction  span=A            (root, no parent)          trace=T
+  navigation    span=B parent=A                              trace=T
+  http.request  span=C parent=A   traceparent 00-T-C-01      trace=T
+  http.request  span=D parent=A   traceparent 00-T-D-01      trace=T
+```
+
+<!-- ceiling: two-level flat tree — network calls parent to the root, not to the nav span. Deeper
+     nesting (tap→nav→http) needs an active-parent stack; deferred to fog. -->
+
+## Coordination
+
+| Ticket | What #43 adds |
+|---|---|
+| **#42** (`ui.interaction`) | observer calls `onInteraction()`; merges returned attrs onto the interaction event |
+| **#40** (network interceptor) | inject `traceparent` before `proceed()`; merge trace attrs onto `http.request` |
+| screen tracker (#35) | `navigation` event calls `onNavigation()`; merges returned attrs |
+| **#30** (envelope) | `trace.id`/`span.id`/`parent.span.id` are optional attrs through the existing enrichment path — no envelope change, only present on trace-participating events |
+| **#34** (ids) | `IdGenerator` gains `traceId()`/`spanId()` raw-hex helpers on the existing `SecureRandom` |
+| lifecycle observer | `ProcessLifecycleOwner` `onStop` → `onBackground()` |
+
+## Flag to hub (upstream proposal — android decided, backend + other SDKs must conform)
+
+The **whole contract** is an android-first proposal for `NCG-Africa/edge_rum_spec`:
+
+1. **Backend must read `traceparent`** and continue the same `trace.id` for the app-side trace to
+   stitch to backend spans. Without this the injection is inert. **Hard dependency on the backend.**
+2. **Semantic-convention names** `trace.id` / `span.id` / `parent.span.id` proposed as the cross-SDK
+   trace attribute set on the unified envelope.
+3. **W3C Trace Context** (128-bit trace, 64-bit span, `traceparent` v0) proposed as the shared
+   propagation format for all SDKs.
+
+Upstream-rejection risk is accepted per the map ("new features decided android-local").
+
+## Test plan
+
+1. **Interaction opens a root** — a `ui.interaction` carries `trace.id` (`^[0-9a-f]{32}$`) + `span.id`
+   (`^[0-9a-f]{16}$`) and **no** `parent.span.id`.
+2. **Tap → network child** — an `http.request` after an interaction carries the **same** `trace.id`, a
+   fresh `span.id`, `parent.span.id` == the root span; the outgoing request has header
+   `^00-[0-9a-f]{32}-[0-9a-f]{16}-01$` with the matching trace/parent ids.
+3. **Navigation linkage** — nav within 1000 ms of an interaction is a **child** (parent = root);
+   a cold nav (no recent interaction) opens a **new** root (no parent).
+4. **Background clears** — a network call after `onBackground()` emits `http.request` with **no** trace
+   attrs and **no** `traceparent` header.
+5. **Sampling** — with `traceSampleRate = 0.0`, no event carries trace attrs and no request carries a
+   header; with `1.0`, every eligible event/request does.
+6. **No overwrite** — a request that already has a `traceparent` keeps it unchanged.
+
+## Files touched (execution, downstream)
+
+| File | Change |
+|---|---|
+| `core/trace/TraceManager.kt` | **new** — the holder + `onInteraction`/`onNavigation`/`onNetworkCall`/`onBackground` |
+| `core/ids/IdGenerator.kt` | add `traceId()` (32 hex) + `spanId()` (16 hex) on the existing `SecureRandom` |
+| `core/TelemetryConfig.kt` | add `traceSampleRate: Double = 1.0` (+ `0.0..1.0` validation); wire into `TraceManager` at init |
+| #42 interaction observer | call `onInteraction()`; merge attrs onto `ui.interaction` |
+| screen/nav tracker (#35) | call `onNavigation()`; merge attrs onto `navigation` |
+| `core/TelemetryInterceptor.kt` (#40) | inject `traceparent`; merge trace attrs onto `http.request` |
+| lifecycle observer | `ProcessLifecycleOwner` `onStop` → `onBackground()` |
+
+## Fog graduated
+
+- **Accurate cross-coroutine parenting** — replace the process-global current-root with
+  thread/coroutine context propagation so a call parents to the span that actually launched it.
+- **Deeper span nesting** — active-parent stack for tap → nav → http trees beyond the flat two-level.
+- **Manual span API** — `startSpan()/endSpan()` (or a `withSpan {}` block) for developer-defined work
+  units (e.g. a JSON parse, a DB read) inside a trace.
+- **`tracestate` / baggage** propagation and **tail / deferred sampling** (W3C-strict `flags=00`
+  propagation of unsampled traces).
+- **Orphan background-call traces** — give background/no-interaction network calls their own root if
+  backend wants them traced.

--- a/docs/specs/edgerum-conformance-execution.md
+++ b/docs/specs/edgerum-conformance-execution.md
@@ -1,0 +1,133 @@
+# EdgeRUM conformance + new datapoints — execution PRD
+
+Rolls the 15 closed planning specs from wayfinder map [#29](https://github.com/NCG-Africa/edge_telemetry_android/issues/29) into one buildable handoff. The map was plan-only; this is the "now build it" spec. Each decision below links its source spec — read the linked `.md` for file:line detail and rationale; this PRD is the execution order, seams, and acceptance surface.
+
+## Problem Statement
+
+A consuming app integrates `edge_telemetry_android` expecting its telemetry to land, whole and correctly shaped, in the EdgeRUM backend. Today it doesn't:
+
+- The SDK emits **two different envelope shapes** and two disjoint network-event schemas, so auto-captured HTTP is dark server-side and crash data races itself to disk and loses.
+- Timestamps carry a literal `Z` on **device-local** time, so every non-UTC device is silently wrong by its offset — and `Instant.now()` crashes outright on Android 7.0/7.1 (the SDK's own min-SDK).
+- Low-activity sessions **hold telemetry forever** (the flush timer Runnable is empty), unbounded buffers can grow without limit, and a per-frame `frame_drop` firehose emits ~36k events/session.
+- ~890 LOC of unwired dead code presents as live attack/audit surface.
+- Three datapoints a RUM product is expected to have — **user interactions, distributed traces, ANR/hang detection** — don't exist.
+
+From the consuming app's perspective: "I integrated the SDK, but my dashboard is missing HTTP calls, my crash session context is empty, my timestamps are skewed, and there's no tap/trace/ANR data at all."
+
+## Solution
+
+Bring the SDK to EdgeRUM wire-format conformance and add the three missing datapoints, in one coordinated pass. Every event leaves on **one `telemetry_batch` envelope** with `sdk.*` common attrs; every timestamp is true-UTC ISO-8601; every network call is one `http.request`; crashes persist synchronously before re-throw with session/user frozen at crash time; buffers are bounded; the frame firehose becomes a windowed summary; dead code is gone; and taps, traces, and ANR/hang land as first-class events. Hub decisions (D1/D3/D6/D7/D8/D9/D11/D14) are fixed input, not re-litigated.
+
+## User Stories
+
+1. As a consuming app developer, I want all telemetry to leave on a single `telemetry_batch` envelope, so that the backend has one shape to parse and no traffic is silently dropped for being the "wrong" format.
+2. As a consuming app developer, I want `sdk.version` and `sdk.platform` on every batch as common attributes, so that the backend can disambiguate SDK versions without relying on `X-SDK-*` headers.
+3. As a backend operator, I want the hard cutover to the unified envelope (no dual-emit), so that I never have to reconcile two live formats from the same SDK version.
+4. As an on-call engineer, I want a crash written synchronously to `filesDir` before the process re-throws, so that fatal crashes are never lost to the async race that drops them today.
+5. As an on-call engineer, I want `session.*` and `user.*` frozen at crash time, so that crash reports carry the context that was live when the app died, not empty or post-death values.
+6. As an on-call engineer, I want crashes to arrive as a standard `app.crash` event with `is_fatal`/`handled` flags, so that fatal and non-fatal errors are queryable the same way as every other event.
+7. As a consuming app developer, I want persisted crashes replayed and deleted only after a 2xx, so that a crash survives an offline death and isn't dropped or duplicated.
+8. As a data analyst, I want every timestamp in ms-precision ISO-8601 true UTC, so that events from devices in any timezone line up on one timeline.
+9. As a consuming app developer on Android 7.0/7.1, I want the SDK to never call `Instant.now()`, so that the SDK doesn't crash on my min-SDK devices — including on the crash rail itself.
+10. As a maintainer, I want one thread-safe UTC time helper instead of seven ad-hoc `SimpleDateFormat`s, so that timestamp formatting can't drift or race.
+11. As a consuming app developer, I want the flush timer to force-send partial batches, so that a low-activity session's telemetry actually ships instead of being held indefinitely.
+12. As a consuming app developer, I want an empty queue to skip the POST, so that idle apps don't generate heartbeat traffic.
+13. As a backend operator, I want the offline store bounded to 200 envelopes drop-oldest, so that an app offline for a long time can't grow storage unboundedly.
+14. As a backend operator, I want the event queue bounded to 500 events drop-oldest, so that a burst can't exhaust device memory.
+15. As a consuming app developer, I want offline replay throttled to ≤10 oldest envelopes per flush tick with stop-on-failure, so that reconnection doesn't stampede the network or the backend.
+16. As a backend operator, I want SDK-minted IDs in the `<kind>_<epochMs>_<16hex>_android` format (D7/D11), so that IDs are self-describing and platform-tagged.
+17. As a backend operator, I want existing persisted device/user IDs preserved verbatim (not regenerated), so that an app update doesn't fork existing installs into phantom devices.
+18. As a data analyst, I want one accurate session lifecycle (no cold-start double-mint, persisted `session_id`), so that session counts and durations are correct.
+19. As a data analyst, I want a single screen-duration signal (`navigation` + `screen.duration`), so that the duplicate pause `screen_view` stops starving the real duration metric.
+20. As a performance analyst, I want a windowed `frame.summary` (jank-rate counters, max timings) instead of per-frame `frame_drop`, so that I get usable jank signal without ~36k events per session.
+21. As a performance analyst, I want fixed Vitals-aligned thresholds (slow >16ms, frozen >700ms) and the device `display.refresh_rate` recorded, so that jank is measured against a real, comparable bar.
+22. As a security auditor, I want ~890 LOC of unwired dead code deleted, so that the audit surface reflects only live functionality.
+23. As a consuming app developer, I want the dead `enableLocationTracking` flag and `testConnectivity()` removed (pre-1.0), so that the public API only exposes things that do something.
+24. As a consuming app developer, I want all network calls unified onto one `http.request` event with D3's `http.*` keys, so that automatically-captured HTTP is no longer dark server-side.
+25. As a consuming app developer, I want the OkHttp interceptor to set `http.success = code in 200..299` (D3a), so that success is a consistent server-readable boolean.
+26. As a security-conscious app, I want query strings stripped from URLs by default (D8), so that tokens and PII in query params never leave the device.
+27. As a consuming app developer, I want a transport failure to still emit `http.request` with `status_code=0`/`success=false`, so that failed calls are observable, not invisible.
+28. As a product analyst, I want automatic user-interaction events (`ui.interaction` discriminated by tap/long_press/swipe), so that I can see what users tap without writing per-view instrumentation.
+29. As a compliance officer at a regulated app, I want interaction capture suppressed on secure surfaces (password `inputType` / `FLAG_SECURE`) by hard default, so that raw taps over a PIN pad can't leak keystroke-inferable coordinates.
+30. As an on-call engineer, I want the last interactions in the crash breadcrumb trail, so that I know what the user tapped before the crash.
+31. As a performance analyst, I want distributed trace/span attributes (`trace.id`/`span.id`/`parent.span.id`) on existing events plus a `traceparent` header injected on outbound calls, so that a user action can be followed from tap through network into backend spans.
+32. As a backend operator, I want the SDK to use W3C Trace Context ids and headers, so that traces stitch to backend spans through a standard the whole stack understands.
+33. As an on-call engineer, I want an `app.anr` event when the main thread is blocked ≥5s, with an all-thread dump, so that I can find the lock-holder behind an ANR.
+34. As an on-call engineer, I want an `app.hang` event with a main-thread stack for sub-5s stalls (≥2s), so that I get a stack trace for the "slow but not an ANR" band that frame counts and ANRs both miss.
+35. As a backend operator, I want ANR and hang to ride the unified envelope with standard enrichment, so that ANR-free and hang-free rates are computable like any other event metric.
+36. As a CI maintainer, I want CI retargeted to `master` running `testDebugUnitTest lintDebug assembleRelease` with the lint gate enforced, so that conformance regressions fail the build.
+37. As a CI maintainer, I want source-grep guards (no timezone-less formatters, no `Instant.now()`, no deleted symbols), so that removed footguns can't silently return.
+38. As a build maintainer, I want the launcher JDK pinned to 17 everywhere and the compile target at 11 via `jvmToolchain(11)`, so that JitPack and local builds are reproducible.
+
+## Implementation Decisions
+
+Grouped by execution wave. Waves reflect the one real dependency: the unified envelope (#30) unblocks the conformance events. Everything else is independent and can proceed in parallel.
+
+### Wave 0 — foundations (unblock everything)
+
+- **Unified wire envelope + `sdk.*`** ([#30](https://github.com/NCG-Africa/edge_telemetry_android/issues/30) · `unified-wire-envelope.md`). One `telemetry_batch` envelope, hard cutover (no dual-emit). `sdk.version`/`sdk.platform` become required common attrs; drop `X-SDK-*` headers. Full serializer + attribute unification. Drop top-level `device_id`/`location`/`tenant_id`. This is the single transport `sendBatch` that Seam 1 asserts against.
+- **CI conformance** ([#31](https://github.com/NCG-Africa/edge_telemetry_android/issues/31) · `ci-conformance.md`). Retarget CI to `master`, drop stale `main`. One job: `testDebugUnitTest lintDebug assembleRelease`; lint gate needs `lint-baseline.xml` + `abortOnError=true`. Pin launcher JDK 17 (add master `jitpack.yml`=`openjdk17`), compile target 11 via `jvmToolchain(11)`. Delete the drifted `-Pversion` override in the java8 `jitpack.yml`. Hosts the Seam 3 source-grep guards.
+- **Timestamp correctness** ([#41](https://github.com/NCG-Africa/edge_telemetry_android/issues/41) · `timestamp-correctness.md`). One representation: ms-precision ISO-8601 true UTC (`yyyy-MM-dd'T'HH:mm:ss.SSS'Z'`, D6). New `core/TelemetryTime.kt` = one `ThreadLocal<SimpleDateFormat>` + UTC (stdlib only, no `java.time`/desugaring). Delete all 7 formatters and all live `Instant.now()` (API-26 crash landmine). Attribute timestamps convert to the same ISO string; `*_ms` durations stay numeric.
+
+### Wave 1 — conformance events (depend on #30)
+
+- **Retire crash Path B** ([#39](https://github.com/NCG-Africa/edge_telemetry_android/issues/39) · `retire-crash-path-b.md`). Crash → standard `app.crash` on two rails: fatal uncaught = synchronous frozen write to `filesDir` **before** re-throw + replay/delete-after-2xx; `trackError`/`recordCrash` = normal batch. D1 unprefixed keys, `is_fatal` JSON bool, `handled` added. `session.*`/`user.*` frozen at crash time. Delete Path B envelope + `getCrashAttributes`.
+- **Unify network schema + URL sanitization** ([#40](https://github.com/NCG-Africa/edge_telemetry_android/issues/40) · `network-schema-sanitization.md`). One event `http.request` with D3 `http.*` keys; interceptor re-keys, adds `http.success = code in 200..299` (D3a). Delete manual `recordNetworkRequest()` (D3). Strip-all query by default (D8). Delete unwired `EdgeTelemetryInterceptor` (owns the full-URL-leak fix #37 deferred here). No `http.error` (failure = `status_code=0`+`success=false`); omit size fields when `contentLength()<0`. Injects `traceparent` for #43.
+
+### Wave 2 — independent hardening (no #30 dependency)
+
+- **Broken timed flush** ([#32](https://github.com/NCG-Africa/edge_telemetry_android/issues/32) · `broken-timed-flush.md`). Inject an `onFlush` lambda into `BatchProcessingService.initialize`; `TelemetryManager` passes `{ scope.launch { sendBatch(forceSend = true) } }`. Timed path force-sends partial batches; empty queue no-ops; `fixedDelay` kept.
+- **Bounded buffers & eviction** ([#33](https://github.com/NCG-Africa/edge_telemetry_android/issues/33) · `bounded-buffers-eviction.md`). Offline = 200-envelope drop-oldest (D9), SharedPreferences + `Mutex`. eventQueue = 500 drop-oldest, size via `AtomicInteger`. Pre-init = 50 FIFO (unchanged). Replay ≤10 oldest/tick, stop-on-failure; delete `restoreOfflineBatches`. Drop dead Room deps.
+- **ID format migration** ([#34](https://github.com/NCG-Africa/edge_telemetry_android/issues/34) · `id-format-migration.md`). Target `<kind>_<epochMs>_<16hex>_android` (D7/D11). Preserve persisted device/user ids verbatim; new format only for newly-minted ids. One-file change (`IdGenerator.generateId(kind)`).
+- **Session + screen correctness** ([#35](https://github.com/NCG-Africa/edge_telemetry_android/issues/35) · `session-screen-correctness.md`). Keep foreground-return rotation; fix cold-start double-mint and unpersisted `session_id`. Persist `session_id`/`session_start`/`last_active` on background; `initialize()` load-then-decide. Retire the pause `screen_view` and deprecated `recordScreenView`/`enableLegacyScreenEvents`; screen lifecycle = `navigation` + `screen.duration`.
+- **Frame metrics windowing** ([#36](https://github.com/NCG-Africa/edge_telemetry_android/issues/36) · `frame-metrics-windowing.md`). Retire per-frame `frame_drop` for windowed `frame.summary`. Hybrid callback-driven window: flush on screen-change (`getCurrentScreen()`) or 10s cap. Jank-rate counters + max timings, no percentiles. Fixed thresholds slow >16ms / frozen >700ms; record `display.refresh_rate`; emit only when `slow_frames>0`; no sampling. Internal `onFrame(totalMs,buildMs,rasterMs)` seam.
+- **Dead-code removal** ([#37](https://github.com/NCG-Africa/edge_telemetry_android/issues/37) · `dead-code-removal.md`). Delete location stack, `JsonEventTracker`, `LegacyPerformanceTracker`(+Wrapper), `TelemetryPayload` wrapper + dead import, `EventBatchPayload` (~890 LOC). Hard-remove public `enableLocationTracking` + `testConnectivity()` (pre-1.0). `EdgeTelemetryInterceptor` deletion folded into #40; Room deps owned by #33.
+
+### Wave 3 — new datapoints (net-new; depend on #30, coordinate with waves above)
+
+- **User-interaction events** ([#42](https://github.com/NCG-Africa/edge_telemetry_android/issues/42) · `user-interaction-events.md`). One `ui.interaction` event discriminated by `ui.type` (tap/long_press/swipe). Capture: wrap `Window.Callback` in the Activity observer (`:36`/`:61`) + `GestureDetector` + decorView hit-test — automatic, no permission. Compose v1 = coordinate-only (`target="compose_surface"`). Target = `getResourceEntryName`→class fallback; raw pixel x/y. **Privacy hard default:** suppress capture on secure surfaces (password-`inputType` `EditText` or `FLAG_SECURE`). Plus a compact crash breadcrumb per interaction.
+- **Distributed trace/span contract** ([#43](https://github.com/NCG-Africa/edge_telemetry_android/issues/43) · `distributed-trace-span.md`). Android-first, flagged upstream. W3C traceparent ids (128-bit trace / 64-bit span, separate from #34's join keys). Root span opens on interaction, else screen; 100% sampling, configurable `traceSampleRate`. One process-global current root (`TraceManager` `AtomicReference`); spans are **attributes** on existing events (`trace.id`/`span.id`/`parent.span.id`) — no new event type. Interaction→new root; nav within 1000ms→child else new root; each network call→child injecting `traceparent: 00-<32hex>-<16hex>-01` (via #40 interceptor); background clears root. Flat two-level tree v1. **Hard hub dependency:** backend must read `traceparent` and continue `trace.id` or the injection is inert.
+- **ANR detection** ([#38](https://github.com/NCG-Africa/edge_telemetry_android/issues/38) · `anr-detection.md`). Watchdog-only main-thread ping/pong daemon (ports Ionic/Capacitor `AnrWatchdog`), API 24+. Fixed 5000ms threshold (internal constant). All-thread dump (main flagged). New `app.anr` event, `is_fatal:false`/`handled:false`, rides unified envelope with standard enrichment. Delivery on #39's durable `filesDir` rail + replay/delete-after-2xx. Foreground-only via `ProcessLifecycleOwner`.
+- **Hang detection** ([#44](https://github.com/NCG-Africa/edge_telemetry_android/issues/44) · `hang-detection.md`). The sub-5s complement to #38. Single 2000ms threshold (band `[2000,5000)`, internal constant). **Reuse the #38 `AnrWatchdog`** — one heartbeat (~1000ms), two thresholds; a stall crossing both emits both `app.hang`(2s) + `app.anr`(5s), dedup intra-threshold. Discrete `app.hang`, main-thread stack only (`hang.stack`), no sampling/aggregation. `is_fatal:false`; normal batch (not the durable rail).
+
+### Cross-cutting contracts
+
+- **Envelope is the contract.** Every event above serializes into #30's `telemetry_batch`. New event names (`app.anr`, `app.hang`, `ui.interaction`) and the `ui.interaction`/trace attr names are android-local, flagged non-blocking to the hub.
+- **`AnrWatchdog` is shared** between #38 and #44 — one daemon, one heartbeat, two thresholds. Build #38 first; #44 adds the second threshold to it.
+- **The #40 interceptor is the trace injection point** — #43 depends on it re-keying + injecting `traceparent` before `proceed()`.
+
+## Testing Decisions
+
+A good test asserts **external behavior only** — the bytes on the wire and observable side effects — never private field state or call order for its own sake. The whole effort tests at three seams the sub-specs already cut; add no new ones.
+
+### Seam 1 — outgoing `telemetry_batch` JSON (primary, highest)
+
+Stub the `sendBatch` HTTP POST (#30's single transport), drive the SDK through its public API + lifecycle callbacks, assert on the serialized batch. This is where the conformance contract lives and where most stories are verified: envelope shape, `sdk.*` common attrs, `app.crash` keys/flags, unified `http.request` (including `status_code=0`/`success=false` on transport failure), ISO-UTC timestamps, `<kind>_..._android` ids, `frame.summary` counters, `ui.interaction` discrimination + secure-surface suppression, trace attributes on events. Prior art: the existing payload/serializer unit tests under `src/test/` — extend the pattern of building a batch and asserting JSON keys.
+
+### Seam 2 — injected collaborators for non-wire behavior
+
+Each defect ticket cut its own seam; test through it, not around it:
+- **Timed flush** (#32) — assert the injected `onFlush` fires on tick and force-sends a partial batch; empty queue no-ops.
+- **Bounded buffers** (#33) — exercise the store APIs directly: seed past the cap, assert drop-oldest; seed 25 stored envelopes, one flush cycle → ≤10 sent, inject a failure at #3 → stop.
+- **Session** (#35) — drive lifecycle callbacks, assert persisted `session_id` and single mint on cold start; resume-within-timeout is silent.
+- **Crash durable rail** (#39) — assert the `filesDir` write happens before re-throw and the file is deleted only after a 2xx replay.
+- **ANR/hang watchdog** (#38/#44) — block a fake main thread, advance a fake clock past 2s then 5s, assert `app.hang` then `app.anr` with the right stack scope and intra-threshold dedup.
+- **Frame windowing** (#36) — feed the `onFrame(totalMs,buildMs,rasterMs)` seam, flush on screen-change, assert counters and the `slow_frames>0` emit floor.
+- **Timestamp** (#41) — unit-test `TelemetryTime.now()` produces true-UTC ISO under a non-UTC default timezone.
+
+### Seam 3 — source-grep guards in CI (#31)
+
+Static conformance for the removals/rewrites that have no runtime assertion: a test that greps the module source and fails on any timezone-less `SimpleDateFormat`, any `Instant.now()`, and any deleted dead-code symbol (`IpLocationProvider`, `JsonEventTracker`, `enableLocationTracking`, etc.). Cheap fence so a footgun can't silently return.
+
+## Out of Scope
+
+- **All items in map #29's "Not yet specified" (fog)** — non-OkHttp manual HTTP capture, query-param allowlist, network breadcrumbs, URL path PII redaction, app-start timing, `ApplicationExitInfo` ANR enrichment, transport compression, collector old-format tolerance, Room-backed offline store, Compose `Modifier.trackTap`, content-desc target, normalized coords, scroll/drag gestures, custom keypad PII rule, cross-coroutine span parenting, deeper span nesting, manual span API, `tracestate`/baggage, orphan background-call traces. Graduate individually only when a real consumer or the hub forces it.
+- **Backend / other-SDK adoption** of the android-decided trace contract, `traceparent` reading, `app.anr`/`app.hang`/`ui.interaction` names — flagged to the hub, tracked there, not here.
+- **Re-litigating hub decisions** (D1/D3/D6/D7/D8/D9/D11/D14) — fixed input.
+
+## Further Notes
+
+- **Ground truth:** repo-root `sdk-audit.yaml` (466 lines, file:line evidence) and `CLAUDE.md`. Each sub-spec cites exact lines; this PRD stays path-light so it doesn't rot.
+- **Hard hub dependency:** #43's trace injection is inert until the backend reads `traceparent` and continues `trace.id`. Ship the android side; the value lands when the hub conforms.
+- **Pre-1.0 latitude:** public API removals (`enableLocationTracking`, `testConnectivity()`, `recordNetworkRequest()`, `recordScreenView`/`enableLegacyScreenEvents`) are hard-removed, no deprecation cycle.
+- **Suggested execution order:** Wave 0 → Wave 1 + Wave 2 in parallel → Wave 3 (#38 before #44; #43 after #40's interceptor). One PR per ticket keeps review and the source-grep guards tractable.

--- a/docs/specs/frame-metrics-windowing.md
+++ b/docs/specs/frame-metrics-windowing.md
@@ -1,0 +1,154 @@
+# Android spec — frame-metric windowing & sampling
+
+Resolves wayfinder ticket **#36** (audit #13). No hub contract pins a frame-metric shape (the
+`edge_rum_spec` #1 map is silent on frame perf), so the emission model is decided **android-local**.
+Evidence: `sdk-audit.yaml:133-144,309-321` + the file:line refs below.
+
+Plan-only. This is the implementation spec; no code is changed on this branch.
+
+---
+
+## Problem
+
+`TelemetryFrameDropCollector` (`core/TelemetryFrameDropCollector.kt:39-69`) emits one `frame_drop`
+event **per frame**, unsampled and unfiltered — even `severity="low"` fires (`:57-69`). At 60fps a
+janky 10-minute session is ~36,000 events; the queue has no per-event dropping and no rate limit
+(`sdk-audit.yaml:309-321`), so frame metrics are the SDK's single largest volume risk. The only
+sampler (`SAMPLING_RATE=0.1`) lives in `LegacyPerformanceTracker` (`:199-211`), which the factory
+never instantiates — dead code, so frame sampling is effectively **off**.
+
+Two more defects on the active path:
+
+1. **`target_fps` hardcoded to 60** (`:49`) → the 16.7ms budget and its 2×/3× severity tiers are
+   wrong on 90/120Hz displays.
+2. **No screen attribution** — the active path attaches no `screen.name` (only the dead legacy
+   variant did, per `sdk-audit.yaml:140`), so a stuttering frame can't be tied to a screen.
+
+## Decision
+
+Replace per-frame emission with **windowed summaries**: at most one `frame.summary` event per
+screen-segment (≤10s), emitted only when the window contained slow frames. All aggregation is
+O(1)-memory counters updated inside the existing frame callback — no timer, no external wiring.
+
+The old `frame_drop` event name and its per-frame severity tiers are **retired**. Nothing downstream
+depends on the active-path name except the collector being rewritten.
+
+---
+
+### 1. Window boundary — hybrid, callback-driven
+
+A window covers one screen segment and closes on whichever comes first:
+
+- **screen change** — `NavigationStackTracker.getCurrentScreen()` (`navigation/NavigationStackTracker.kt:55`)
+  differs from the screen captured at window start. This single source works for both Activity apps
+  and single-Activity Compose apps (navigation pushes cover both).
+- **10s time cap** — `elapsedRealtime - windowStart >= 10_000`.
+
+Both checks run **inside the frame callback**, after the counters are updated. Frames arrive every
+~16ms, so the checks are free and need no separate timer or navigation observer. An idle-but-visible
+screen fires no callbacks → nothing accumulates → nothing to flush (and it would have 0 slow frames
+anyway). The trailing partial window is flushed on `stop()` / app-background.
+
+`screen.name` and `display.refresh_rate` are captured **at window start**.
+
+### 2. Aggregation — jank-rate counters
+
+Per window, maintained as plain counters/running-maxes (no retained per-frame list, no percentiles):
+
+| Accumulator | Update per frame |
+|---|---|
+| `total_frames` | `+1` |
+| `slow_frames` | `+1` if `total_ms > 16` |
+| `frozen_frames` | `+1` if `total_ms > 700` |
+| `max_total_duration_ms` | `max(prev, total_ms)` |
+| `max_build_duration_ms` | `max(prev, build_ms)` |
+| `max_raster_duration_ms` | `max(prev, raster_ms)` |
+
+`slow_frame_rate = slow_frames / total_frames` computed at flush. `frozen_frames` is a subset of
+`slow_frames` (700 > 16). Durations keep the existing derivation:
+`total = TOTAL_DURATION`, `build = LAYOUT_MEASURE_DURATION`, `raster = DRAW_DURATION`
+(`TelemetryFrameDropCollector.kt:41-47`), all ns → ms.
+
+### 3. Thresholds — fixed, Android Vitals–aligned
+
+- **slow** = `total_ms > 16`
+- **frozen** = `total_ms > 700`
+
+Fixed absolute thresholds map to human-perceptible jank and stay directly comparable to Google Play
+Console metrics across devices. The device's actual refresh rate is **recorded, not used to move the
+threshold**: `display.refresh_rate` read at window start (`Activity.display?.refreshRate` on API 30+,
+else `windowManager.defaultDisplay.refreshRate`), so the backend can do refresh-aware analysis later
+without the SDK guessing. The hardcoded `target_fps` and the 2×/3× `severity` tiers are **deleted**.
+
+### 4. Emit floor — slow frames only
+
+A window emits `frame.summary` **only if `slow_frames > 0`**. Perfectly-smooth windows are dropped
+entirely. `total_frames` is still carried inside each emitted window, so per-emitted-screen jank rate
+stays exact; the only thing lost is fleet-wide smooth-screen visibility, a weak signal not worth an
+event per screen visit.
+
+### 5. Sampling — none
+
+100% of qualifying windows are sent. Windowing + the slow-only floor already collapse the ~36,000-event
+session to ≤~60 window events (fewer if screens are smooth); sampling out 90% of *jank* windows would
+cripple the signal exactly where it matters. The per-screen 10s cap is the only backstop. A
+window-level sampling knob can be added later if a pathological app ever floods — not shipped now.
+
+---
+
+## Event shape — `frame.summary`
+
+Rides the unified `telemetry_batch` envelope + common attrs (device/session/user/`sdk.*`) once #30
+lands — already closed; see `docs/specs/unified-wire-envelope.md`. Payload attributes:
+
+```
+frame.total_frames            int      frames observed in the window
+frame.slow_frames             int      total_ms > 16
+frame.frozen_frames           int      total_ms > 700  (subset of slow)
+frame.slow_frame_rate         float    slow_frames / total_frames
+frame.max_total_duration_ms   float    worst single frame, total
+frame.max_build_duration_ms   float    worst single frame, build (layout+measure)
+frame.max_raster_duration_ms  float    worst single frame, raster (draw)
+frame.window_duration_ms      float    wall-clock span of the window
+display.refresh_rate          float    Hz at window start
+screen.name                   string   screen the window covers
+```
+
+No per-window `severity` — the backend derives severity from `slow_frame_rate` / `frozen_frames`.
+
+---
+
+## Collector change — `TelemetryFrameDropCollector`
+
+Rewrite the listener body (`:39-69`) from per-frame emit to accumulate-and-flush:
+
+- Add a mutable window aggregator (the counters/maxes above + `windowStart: Long`,
+  `windowScreen: String?`, `windowRefreshRate: Float`), guarded by the existing `@Synchronized`
+  (frame callback thread vs. `stop()` on main thread).
+- **On each frame:** compute `total/build/raster ms`; if no window is open, open one (capture
+  `getCurrentScreen()`, refresh rate, `elapsedRealtime`); update counters/maxes; then
+  `if (getCurrentScreen() != windowScreen || elapsed >= 10_000) flushWindow()` and open a fresh one.
+- **`flushWindow()`:** if `slow_frames > 0`, `telemetryManager.recordEvent("frame.summary", attrs)`;
+  always reset the aggregator. Still gated by `isFrameTrackingEnabled()`.
+- **`stop()`** (`:91-107`) flushes the trailing window before clearing references.
+- Delete `target_fps`/budget/`severity` computation.
+
+`LegacyPerformanceTracker` stays dead; its `SAMPLING_RATE` is now irrelevant and can be swept in the
+#37 dead-code pass.
+
+---
+
+## Test plan — golden JSON
+
+Robolectric unit tests feeding the collector a synthetic frame sequence (bypassing the real
+`FrameMetrics` via a small internal `onFrame(totalMs, buildMs, rasterMs)` seam):
+
+1. **Counts & maxes** — feed N smooth (`≤16ms`) + M slow (`16<ms≤700`) + 1 frozen (`>700ms`) frames,
+   force a flush, assert the emitted `frame.summary` JSON exactly matches a golden payload:
+   `total_frames = N+M+1`, `slow_frames = M+1`, `frozen_frames = 1`,
+   `slow_frame_rate = (M+1)/(N+M+1)`, and the three `max_*` equal the largest fed values.
+2. **No-emit floor** — feed only smooth frames, force a flush, assert **no** event recorded.
+3. **Screen-change split** — feed slow frames under screen A, flip `getCurrentScreen()` to B, feed
+   more slow frames, assert **two** `frame.summary` events with `screen.name` A then B.
+4. **10s cap** — advance the clock past 10s within one screen, assert the window flushes and a new
+   one opens.

--- a/docs/specs/hang-detection.md
+++ b/docs/specs/hang-detection.md
@@ -1,0 +1,182 @@
+# Android spec — hang detection (sub-5s main-thread stalls)
+
+Resolves wayfinder ticket **#44** (feature-matrix `hang-detection: planned`, `sdk-audit.yaml`).
+Net-new datapoint — no hang / sub-ANR stall code today. Complement to **ANR** (#38,
+`docs/specs/anr-detection.md`): ANR owns the ≥5s upper band and built the main-thread watchdog
+primitive; hang detection is the "slow but not an ANR" band users still feel.
+
+Fixed input:
+- **ANR watchdog** (#38, `docs/specs/anr-detection.md`) — the heartbeat primitive this extends.
+- **frame.summary** (#36, `docs/specs/frame-metrics-windowing.md`) — the lower neighbour; counts
+  `frozen_frames` (>700ms) as a windowed *rate*.
+- **unified envelope + enrichment** (#30, `docs/specs/unified-wire-envelope.md`).
+- **bounded buffers** (#33, `docs/specs/bounded-buffers-eviction.md`) — the `eventQueue` 500-cap
+  drop-oldest that backstops volume.
+
+Plan-only. This is the implementation spec; no code is changed on this branch.
+
+## Problem
+
+The main thread can stall for 1–5 seconds — a slow DB query on the UI thread, a synchronous image
+decode, a large JSON parse, a blocking disk read — long enough that the user sees a visible freeze,
+but **short of the 5s system ANR line** (#38). This band is uninstrumented as a diagnosable event.
+
+The two neighbours don't cover it:
+- **#36 `frame.summary`** counts `frozen_frames` (>700ms) but only as an **aggregate rate**, and
+  only for frames that eventually render — it carries **no stack trace**. It tells you a screen was
+  janky, not *what code* froze it. It also can't see a true hang where the `Choreographer` callback
+  itself is blocked and no frame is submitted.
+- **#38 `app.anr`** only fires at ≥5s. A 2.5s freeze — clearly felt by the user — produces nothing.
+
+So the value hang detection adds over both: a **stack trace of what blocked the main thread**, for
+stalls in the band `frame.summary` can only count and `app.anr` never sees.
+
+## Decisions (from grilling #44)
+
+### 1. Threshold — single 2000 ms line, no tiers
+
+Hang is defined as **main thread blocked ≥ 2000 ms and < 5000 ms**. Band `[2000, 5000)`.
+
+- **Lower bound 2000 ms**, not the 700ms frozen-frame line. 700ms–2s is already served by
+  `frame.summary`'s frozen-frame *rate* (#36); adding stack-trace events there would be high-volume
+  for a weak signal. 2s is unambiguously "the user noticed a freeze."
+- **Upper bound 5000 ms** = the ANR line (#38 §2). Non-overlapping by construction: a stall that
+  reaches 5s is an ANR, not a hang (see §2 for the escalation rule).
+- **No severity tiers.** Severity is just `hang.duration_ms`; the backend buckets it — same posture
+  as #36 ("backend derives severity") and #38's fixed threshold. Tiers would re-import the volume
+  problem inside the band.
+- **Internal constant, not a config flag** (ponytail: no config for a value that won't change;
+  matches #38 §2). Upgrade path: promote to `TelemetryConfig` only if a consumer needs a different
+  line.
+
+The threshold choice **is** the primary volume control (see §3): 2s keeps discrete hang events rare
+enough that no sampler or aggregate is needed.
+
+### 2. Mechanism — reuse the #38 `AnrWatchdog`, two thresholds off one heartbeat
+
+Detecting a 2s stall vs a 5s stall is the **same measurement** (how long the heartbeat `Runnable`
+took to run on the main `Looper`) read against two constants. So the #38 watchdog is **extended**,
+not duplicated:
+
+- **One daemon thread, one heartbeat, two comparisons.** No second detector.
+- **Heartbeat interval drops** to catch a 2s stall in one scan: `min(hangThreshold/2, anrInterval)`
+  ≈ **1000 ms** (#38 floored at 500ms for the 5s line; keeping 500ms is also fine). Cheaper posts,
+  still negligible.
+- **One stall can cross both lines → emit both events.** A single unbroken 6s block is *both* a
+  hang (≥2s) *and* an ANR (≥5s). The watchdog fires **`app.hang` when the stall crosses 2s**, and if
+  that *same* stall later crosses 5s it *also* fires **`app.anr`**. They're distinct signals
+  (one "it froze," one "system-level ANR") and dashboards want **hang-free** and **ANR-free** rates
+  independently countable. Dedup is **intra-threshold** (one hang per stall, one anr per stall),
+  **not** cross-threshold — the terminal ANR does not suppress its own precursor hang.
+- **Intra-hang dedup** reuses #38's post-fire sleep: after firing `app.hang`, the watchdog waits out
+  the rest of the stall before re-scanning, so one unbroken freeze = **one** `app.hang`.
+
+### 3. Volume control — discrete events, no sampling, no aggregation
+
+**Discrete `app.hang` events.** No `hang.summary` aggregate, no sampler.
+
+A slow frame is only meaningful as a *rate* (36k of them, individually meaningless) → #36 aggregates.
+A hang is the **opposite**: a discrete, individually-diagnosable freeze **with a stack trace**.
+Aggregating hangs into a count+max would discard the stack — the entire reason hang detection exists
+over `frame.summary`'s frozen counter. So aggregation here destroys the signal it carries.
+
+Volume stays bounded without a sampler:
+- **Physics caps it** — you cannot fit more than ~30 two-second stalls into a foreground minute; a
+  real app has a handful per session. Nothing like the per-frame firehose that forced #36.
+- **Intra-hang dedup** (§2) — one event per unbroken stall.
+- **Global backstop already exists** — #33 bounds `eventQueue` at 500 events, drop-oldest. A
+  pathological app that somehow floods hangs is capped by that **shared** bound. No hang-specific cap
+  or sampler is built (ponytail: don't add a second limiter for what #33 already limits).
+
+### 4. Capture — main-thread stack only
+
+`app.hang` dumps **only the main thread's** stack. The all-thread dump stays **exclusive to
+`app.anr`** (#38 §3).
+
+- A 2s stall is overwhelmingly **slow synchronous main-thread work** — the culprit *is* on the main
+  thread's own stack. An all-thread dump adds noise, not signal.
+- The one case needing the lock-*holder* thread — a genuine deadlock — **does not resolve in 2s**.
+  It keeps blocking, escalates past 5s, and becomes an `app.anr`, which #38 *already* captures with
+  the full `Thread.getAllStackTraces()` dump. So the expensive diagnostic is preserved exactly where
+  it pays off and never duplicated.
+- **Frequency-matched cost:** hangs fire more often than ANRs, so the cheaper single-thread capture
+  is the right weight (ponytail).
+
+Result: `anr.threads` (array, main flagged) becomes, for hang, a single `hang.stack` string.
+
+### 5. Event identity + shape — `app.hang`
+
+Distinct event name, mirroring `app.anr` minus the all-thread array. Emitted through the same
+`EventAttributes` enrichment as everything else (#30), so it automatically carries
+`session.*` / `user.*` / `sdk.*`, frozen at detection time (same freeze discipline as crash/ANR,
+audit #1).
+
+Shape (D1 unprefixed keys, JSON-typed, consistent with #38/#39):
+
+```
+event  app.hang
+  is_fatal      false      process survives a sub-5s stall (below the ANR line)
+  handled       false      auto-detected, not caught by app code (matches #38)
+attributes
+  hang.duration_ms   <int>     main thread blocked this long (SystemClock.uptimeMillis delta)
+  screen             <string>  current screen at detection (getCurrentScreen(), Activity + Compose — same source as #36/#38)
+  hang.stack         <string>  main-thread stack, "at a.b(f:1)\n..." (single thread, §4)
+  session.*, user.*  frozen at detection time
+```
+
+No `severity` field (§1 — duration is the severity). No `hang.threads` array (§4).
+
+### 6. Delivery — normal in-memory batch (NOT the durable rail)
+
+`app.hang` enqueues to the **normal batch**. It does **not** use #39's synchronous `filesDir`
+durable-fatal rail.
+
+#38 persists because the system can kill the app *during* a ≥5s ANR, losing an in-memory event. A
+hang is **below** the ANR line by definition — the process virtually always survives a 2s stall
+(that's what makes it a hang and not an ANR). So the durability justification does not hold; writing
+every hang to disk is I/O nothing needs (ponytail: don't persist what doesn't need to survive).
+
+The durable case stays covered anyway: a stall severe enough to get the app killed has crossed 5s →
+it is *also* an `app.anr` (§2), which *does* persist on the #39 rail. So no hang is lost that matters,
+and no new persistence code is added.
+
+## Lifecycle
+
+Inherited from the #38 watchdog it extends — no new lifecycle wiring:
+- **Start** after `initialize()` completes (SDK ready), alongside the ANR threshold.
+- **Foreground-only:** paused on background / resumed on foreground via the existing
+  `ProcessLifecycleOwner` observer. Sub-5s stalls are user-facing foreground events; no reason to
+  wake a backgrounded device.
+- Daemon thread; stops on process teardown / `resetForTesting()`.
+
+## Files (touched)
+
+| File | Change |
+|---|---|
+| `core/anr/AnrWatchdog.kt` | **Extend** (#38's new file). Add the 2000ms hang threshold + ~1000ms heartbeat; on a stall crossing 2s emit `app.hang` (main-thread stack), on the same stall crossing 5s also emit `app.anr`; intra-threshold dedup for each. |
+| `core/services/CrashReportingService.kt` (or the #38 `AnrService`) | Emits `app.hang` via the enrichment path to the **normal batch** (§6) — no durable-rail wiring for hang. |
+| `TelemetryConfig.kt` | No public flag (§1). |
+
+No changes to `TelemetryManager` lifecycle beyond what #38 already adds (same watchdog start/stop).
+
+## Test plan
+
+Extends #38's watchdog test harness:
+
+- **Unit (Robolectric):** block the main `Looper` for ~2.5s (a `Thread.sleep` posted to it) →
+  exactly **one** `app.hang`, `hang.duration_ms ≥ 2000` and `< 5000`, `hang.stack` non-empty and
+  main-thread only, `is_fatal:false`, and **no** `filesDir` record (normal batch, §6). Unblock
+  before 2s → **zero** events (no false positive).
+- **Escalation (both events):** a single unbroken ~6s block → **exactly one** `app.hang` *and*
+  **exactly one** `app.anr` (§2), not two hangs and not a suppressed hang.
+- **Intra-hang dedup:** a 3s block → exactly one `app.hang`, not ~3.
+- **Band boundary:** a 4.9s block → one `app.hang`, **no** `app.anr`; a 5.1s block → one `app.hang`
+  + one `app.anr`.
+- **Lifecycle:** background → no heartbeats posted (spy the handler); foreground resumes (shared
+  with #38).
+
+## Not a hub gap
+
+Hang detection is decided android-local (no hub hang contract). The `app.hang` event name +
+attribute shape is proposed android-first; other SDKs conform if/when they add hang detection. Flag
+the name to the hub for cross-SDK consistency (alongside `app.anr`), don't block on it.

--- a/docs/specs/id-format-migration.md
+++ b/docs/specs/id-format-migration.md
@@ -1,0 +1,85 @@
+# Android spec — ID format migration (D7)
+
+Resolves wayfinder ticket **#34** (audit #9). Hub decision **D7** taken as given; this is the
+android *how*. Independent of the envelope (#30) — ids are opaque strings on the wire. Evidence:
+`sdk-audit.yaml:262-266, 335-338` + file:line refs below.
+
+Plan-only. This is the implementation spec; no code is changed on this branch.
+
+## Given (hub D7)
+
+> **IDs** — `<kind>_<epochMs>_<16hex>_<platform>` with crypto entropy; Android migrates format.
+> (`edge_rum_spec` `SPEC_V1_DECISIONS.md`, D7.)
+
+## Today
+
+`IdGenerator.generateId()` = `"${System.currentTimeMillis()}_${8 random [a-z0-9]}"`, e.g.
+`1736899200000_a3k9zq1m` — **same shape for device, session, and user** ids
+(`core/ids/IdGenerator.kt:13-16,64-78`). `java.util.UUID` is imported but unused. Entropy is already
+crypto (`SecureRandom`, `:16`); what's non-conformant is the **charset (36→hex), width (8→16), and the
+missing `kind`/`platform` tokens**.
+
+- **device.id** — persisted in `SharedPreferences("edge_telemetry_ids")` key `device_id`; emitted as
+  `device.id` on every event (`device/DeviceInfoCollector.kt:30`). This is the identity join key downstream.
+- **user.id** — persisted key `edge_rum_user_id`, generated on first access, never null; emitted as `user.id`.
+- **session.id** — ephemeral, minted per session (`services/SessionService.kt:39,58`), never persisted.
+
+## Decisions
+
+### 1. Target format
+
+`<kind>_<epochMs>_<16hex>_android`
+
+- **kind** ∈ `device` | `session` | `user` (one token per getter, no shared `generateId()`).
+- **epochMs** — `System.currentTimeMillis()`, unchanged.
+- **16hex** — 16 lowercase hex chars (64 bits) from the existing `SecureRandom`. Replaces the 8-char
+  base-36 string. `CHARS`/`RANDOM_LENGTH` deleted; use `Long.toHexString`-style fill or hex of 8 random bytes.
+- **platform** — literal `"android"`, matching `sdk.platform` (D11 enum, locked by #30
+  `docs/specs/unified-wire-envelope.md:47`). Hardcoded — this is an android-only AAR.
+
+Example: `session_1736899200000_a3f5c9017be24d08_android`.
+
+### 2. Migration — preserve persisted ids, new format only for newly-minted ids
+
+**device.id and user.id already in `edge_telemetry_ids` are returned verbatim (legacy shape). The new
+format applies only to ids minted from now on** (fresh installs; user.id on first-ever access; every
+session.id, since sessions are never persisted).
+
+**Why not regenerate:** device.id is the downstream identity join key; ids are **opaque strings** to the
+collector (nothing parses `<kind>` or `<platform>` out of them — platform travels separately as
+`sdk.platform`, D11). Rewriting a persisted device_id/user_id would fork every existing install into a
+phantom "new device", orphaning its history — for zero wire benefit. So preserve.
+
+Consequence, and it's fine: an upgraded install emits a **legacy** `device.id` next to a **new-format**
+`session.id` in the same batch. They're independent opaque keys; no invariant couples their shapes.
+
+### 3. No dual-write, no upgrade marker
+
+No "legacy vs migrated" flag, no backfill pass. YAGNI — the SharedPreferences read already distinguishes
+"present" (→ preserve) from "absent" (→ mint new). Prefs **storage keys** (`device_id`,
+`edge_rum_user_id`) are unchanged; only the *value shape* of newly-minted ids changes.
+
+## Changes
+
+| File | Change |
+|---|---|
+| `core/ids/IdGenerator.kt:64-78` | `generateId()` → `generateId(kind)` = `"${kind}_${now}_${hex16()}_android"`; add `hex16()` (16 hex from `SecureRandom`); delete `CHARS`, `RANDOM_LENGTH`, `generateRandomString`. |
+| `core/ids/IdGenerator.kt:37,49,57` | callers pass their kind: `generateId("device")`, `generateSessionId()`→`generateId("session")`, `getUserId()`→`generateId("user")`. |
+| `core/ids/IdGenerator.kt:5` (import) | remove unused `java.util.UUID` if present (audit #9 dead-import). |
+| `getOrGenerateDeviceId()` / `getUserId()` | **no change to the get-or-create logic** — persisted value still returned as-is; only the `?: run { … }` mint branch yields the new shape. |
+
+No consumer changes: `DeviceInfoCollector`, `SessionService`, `UserProfileService`, `CrashReporter`,
+`JsonEventTracker` all take the id as an opaque string.
+
+## Test plan
+
+- **Fresh install** — `device.id`, `user.id`, `session.id` each match `^(device|user|session)_\d+_[0-9a-f]{16}_android$`.
+- **Upgraded install** — pre-seed `edge_telemetry_ids/device_id=1736899200000_a3k9zq1m` and
+  `edge_rum_user_id=…`; assert `getDeviceId()` / `getUserId()` return those **legacy strings unchanged**.
+- **Session always new** — on an upgraded install, `session.id` is still new-format (no persisted session to preserve).
+- **Entropy** — 16 hex = 64 bits; adequate collision resistance for device/session/user id volume.
+
+## Flag to hub
+
+None. D7 says "Android migrates format"; the preserve-legacy-persisted-ids choice is an android storage
+detail, invisible on the wire (opaque strings). No hub-contract gap surfaced.

--- a/docs/specs/retire-crash-path-b.md
+++ b/docs/specs/retire-crash-path-b.md
@@ -1,0 +1,152 @@
+# Android spec — retire crash Path B, attach session + user
+
+Resolves wayfinder ticket **#39** (audit #1, hub decision **D1**). Builds on the unified
+envelope spec (**#30**, `docs/specs/unified-wire-envelope.md`) — that envelope is fixed input.
+Evidence for current state: `sdk-audit.yaml` (repo root) + file:line refs below.
+
+Plan-only. This is the implementation spec; no code is changed on this branch.
+
+## Problem
+
+HEAD (`2.1.13`) runs crashes down a **separate pipeline** from all other telemetry:
+
+- `CrashReporter` (installed `UncaughtExceptionHandler` + **all** `trackError()` overloads)
+  → `FlutterPayloadFactory.createCrashBatchEnvelope()` → `CrashBatchEnvelope`
+  → `CrashRetryManager.sendCrashData` (`:131-145`).
+- Its own envelope (`{timestamp, device_id, data:{tenant_id, location, ...}}`), its own Gson,
+  its own `X-SDK-*` headers, crash attrs from `DeviceInfoCollector.getCrashAttributes()` —
+  **device + app + network only, NO `session.*`, NO `user.*`** (`sdk-audit.yaml:193-209`).
+
+Result (audit #1, the top PROD bug): the processor keys on `session.id`/`user.id`, so it **drops
+every genuine crash**. Only manual `recordCrash()` (which rides the batch/event path, "Path A")
+lands. And `is_fatal` is a stringified `"true"` on Path B vs a JSON bool on Path A — two
+incompatible schemas under one `eventName: "app.crash"`.
+
+**Two further latent bugs found while specing this:**
+
+1. **Fatal crashes barely land at all today.** The uncaught handler (`CrashReporter.kt:151-162`)
+   does `scope.launch { sendCrashData }` then **immediately** calls
+   `originalHandler.uncaughtException(...)` in `finally` (`:76`) — which terminates the process.
+   The async coroutine races process death and usually loses. Path B's "durability" is real only
+   for non-fatal `trackError()` (process alive) and for retries — not for actual fatal crashes.
+2. **Offline crash storage is on `cacheDir`** (`CrashRetryManager.kt:66`), which the OS **evicts
+   under storage pressure**. So it is not the eviction-exempt store it claims to be.
+
+## Decisions (from grilling #39)
+
+### 1. Two rails, three entry points
+
+Crash stops being a separate envelope. Every crash becomes an `app.crash` **event** built through
+the **same** `EventAttributes` enrichment as every other event (#30), so it automatically carries
+`session.*`, `user.*`, `sdk.*` — killing the Path B context gap (D1). There are exactly **two
+rails**, keyed on whether the process is dying:
+
+| Entry point | Rail | `is_fatal` | `handled` |
+|---|---|---|---|
+| Uncaught `UncaughtExceptionHandler` | **Durable-fatal** (synchronous write, §2) | `true` | `false` |
+| `trackError(...)` | **Normal batch** | `false` | `true` |
+| `recordCrash(throwable)` | **Normal batch** | `false` | `true` |
+
+- **Normal batch** = enrich as an `app.crash` event, queue into the standard batch; it gets the
+  same batching, flush, and offline-retry every event already gets. No dedicated immediate-flush,
+  no dedicated crash file. `trackError()` and `recordCrash()` become indistinguishable on the wire
+  (both "SDK-reported handled error") — accepted; `recordCrash` is now effectively a `trackError`
+  alias. Drops `recordCrash`'s bespoke `telemetry_pending_crash.json`.
+- **Durable-fatal** is the only special case — see §2.
+
+Trade-off accepted: a `trackError()`/`recordCrash()` recorded microseconds before an unrelated
+process death can be lost with its unflushed batch. It is non-fatal and breadcrumbs still capture
+it.
+
+### 2. Durable-fatal path (fixes the two latent bugs)
+
+On an uncaught exception the handler MUST, **synchronously, on the crashing thread, before**
+calling the original handler:
+
+1. Build the fully-enriched `app.crash` event — `session.*`/`user.*`/`sdk.*`/`device.*`/`app.*`
+   captured from the **crashing** session, plus the §3 crash keys.
+2. **Freeze** it: serialize the complete event and write it to a single crash file with a blocking
+   write + `fd.sync()`. Replay sends it **as-is** — never re-enrich at replay time (that would
+   stamp the *new* session onto an old crash).
+3. Then call `originalHandler.uncaughtException(...)`.
+
+Storage:
+- **`filesDir`, not `cacheDir`** — survives OS eviction; cleared only on uninstall / clear-data.
+- **No `RandomAccessFile` + `FileLock`.** After decision 1 the durable file has exactly **one
+  writer** (the uncaught handler, single dying thread). Plain `writeText` + fsync. Delete the lock
+  machinery (`CrashRetryManager.kt:71,172-201`).
+
+Replay on `TelemetryManager.initialize()`:
+- Read the `filesDir` crash file → build a single-event `telemetry_batch` → send via the **shared
+  POST helper** (#30, one transport for both rails) → delete the file **only on HTTP 2xx**
+  (delete-after-**send**, not after-enqueue: the frozen crash survives across launches until
+  actually delivered).
+- On failure / offline: leave the file, let **WorkManager** retry (keeps the flush/retry timing
+  #30 preserved). Crash delivery stays independent of normal batch-flush timing.
+
+### 3. Canonical `app.crash` key set
+
+D1 shape: **unprefixed, natively-typed** keys. Reconciliation of every field both current paths
+emit onto the one canonical set:
+
+| Path A (`recordCrash`) | Path B (uncaught/`trackError`) | → Canonical | Type |
+|---|---|---|---|
+| `error.message` | `message` | `message` | string ≤1000 |
+| `error.stack_trace` | `stacktrace` | `stacktrace` | string ≤2000 |
+| `error.exception_type` | `exception_type` | `exception_type` | string ≤255 |
+| `error.cause` | `cause` | `cause` | string ≤255 |
+| `error.context` | `error_context` | `error_context` | string ≤500 |
+| `error.is_fatal` (bool) | `is_fatal` (`"true"` string) | `is_fatal` | **JSON bool** |
+| — | `user_action` | `user_action` | string ≤500 |
+| — | `error_code` | `error_code` | string ≤100 |
+| `error.breadcrumbs` | `breadcrumbs` | `crash.breadcrumbs` | JSON string |
+| — | `crash.thread`, `crash.is_main_thread` | keep (uncaught only) | string, **JSON bool** |
+| — | — | `handled` (new) | JSON bool |
+
+**Dropped:**
+- `error.severity_level` (Path A) — server-computed severity (D1).
+- `error.breadcrumb_count` (Path A) — derivable server-side from `crash.breadcrumbs`.
+- `product_id` (Path B) — dropped from the wire. **Follow-up:** `trackError(productId=...)` and
+  `setProductContext()` no longer reach the crash wire; retire or repurpose the param (not blocking
+  #39).
+- `crash_hash` / `severity` — never SDK-sent (server-computed).
+- `tenant_id` / `location` / `device_id` top-level / `data{}` wrapper — gone with the Path B
+  envelope (#30).
+
+## Code changes
+
+| Area | Change |
+|---|---|
+| `core/crash/CrashReporter.kt:66-78` | Uncaught handler: build + **synchronously** write frozen `app.crash` event to `filesDir` **before** `originalHandler.uncaughtException`. No `scope.launch` on the fatal path. |
+| `core/crash/CrashReporter.kt:84-127` | `trackError(...)` overloads: enrich as `app.crash` event (`is_fatal=false, handled=true`) → **normal batch rail**, not `sendCrashData`. |
+| `core/crash/CrashReporter.kt:151-190` | Delete `handleCrash` async path + `createCrashBatchEnvelope`; fatal path is the synchronous writer above. |
+| `core/services/CrashReportingService.kt` | `recordCrash(throwable)` → enrich as `app.crash` event (`is_fatal=false, handled=true`) → normal batch rail; drop `telemetry_pending_crash.json` persistence. |
+| `core/payload/FlutterCompatiblePayload.kt:268-369` | **Delete** `CrashBatchEnvelope` + `createCrashBatchEnvelope` overloads. |
+| `core/retry/CrashRetryManager.kt` | Repurpose to: replay `filesDir` crash file on init → single-event `telemetry_batch` → shared POST helper → delete-on-2xx; WorkManager retry on failure. **Delete** bespoke Gson, `X-SDK-*` headers (`:139-140`), `FileLock`/`RandomAccessFile` (`:71,172-201`). Move store from `cacheDir` → `filesDir`. |
+| `core/device/DeviceInfoCollector.kt:95` (`getCrashAttributes`) | Retire — crash uses full common enrichment. |
+
+Single envelope, single enrichment, single transport (#30); one crash-specific mechanism only:
+the synchronous durable write for fatals.
+
+## Test plan
+
+Golden-JSON + Robolectric (`src/test/`):
+
+1. **Crash-during-session carries context** (the audit #1 regression guard) — start a session, set
+   a user profile, fire a crash; assert the emitted `app.crash` event carries `session.id` **and**
+   `user.id` matching the active session.
+2. **Fatal survives process death** — install handler, write a crash to `filesDir` via the
+   synchronous path, simulate restart (`resetForTesting()` + new init), assert the frozen event is
+   replayed and sent with its **original** `session.id` (not a fresh one), and the file is deleted
+   only after a 2xx (stub non-2xx → file remains).
+3. **Native `is_fatal`** — assert `is_fatal` serializes as JSON boolean for all three entry points
+   (no `"true"` string), `handled` matches the matrix.
+4. **Canonical keys** — assert unprefixed keys, `crash.breadcrumbs` present, and **absence** of
+   `error.*` prefixes, `severity_level`, `breadcrumb_count`, `product_id`, `tenant_id`.
+5. **Path B gone** — assert no request carries `X-SDK-Version`/`X-SDK-Platform` headers and no
+   `data{}`-wrapped envelope is ever produced by the crash path.
+
+## Downstream
+
+Depends on the unified envelope + shared enrichment/transport from **#30**. Sibling conformance
+tickets (`#40` network, `#41` timestamp) reuse the same envelope; no ordering dependency on #39.

--- a/docs/specs/session-screen-correctness.md
+++ b/docs/specs/session-screen-correctness.md
@@ -1,0 +1,200 @@
+# Android spec — session-timeout & duplicate `screen_view` correctness
+
+Resolves wayfinder ticket **#35** (audit #10). Two independent correctness fixes. No hub
+session contract exists (the `edge_rum_spec` #1 map pins no session-timeout decision), so the
+evaluation model is decided **android-local**. Evidence: `sdk-audit.yaml:66-74,245-266` + the
+file:line refs below.
+
+Plan-only. This is the implementation spec; no code is changed on this branch.
+
+---
+
+## Part 1 — Session timeout evaluation model
+
+### Problem
+
+Timeout is evaluated **only on foreground return** (`onStart`), against `last_active_timestamp`,
+which is written **only on background** (`onStop`) — so it really means *last-backgrounded-at*.
+Two concrete defects, not a wrong model:
+
+1. **Cold-start double-session / double-count.** `SessionService.initialize()`
+   (`core/services/SessionService.kt:38-48`) *always* mints a new `session_id` and increments
+   persisted `total_sessions`. The very next `onStart` runs `hasSessionTimedOut()`
+   (`TelemetryManager.kt:405-421`) and, if timed out, emits `session.finalized` + calls
+   `startNewSession()` — minting **again** and incrementing `total_sessions` **again**. A cold
+   start after >30 min in background produces two sessions back-to-back and double-counts.
+
+2. **`session_id` is not persisted**, so the "reopen within 30 min = same session" intent the
+   timeout implies is already broken across process death: the OS routinely kills backgrounded
+   Android apps, and today every reopen after a kill gets a fresh id regardless of elapsed time.
+
+Foreground-return evaluation itself is *fine* — it matches the standard mobile model (Firebase/GA4
+rotate on return-to-foreground after N minutes of background). No background timer is wanted: waking
+the process to rotate a session no one is looking at is pure cost.
+
+### Decision
+
+**Foreground-return rotation, made correct by persisting the session and resuming it across process
+death.** No background timer. No per-event idle clock.
+
+#### 1. Persist the session on background
+
+On `onStop` (`TelemetryManager.kt:431-447`), alongside the existing `last_active` write, persist
+`session_id` and `session_start` to `telemetry_prefs`:
+
+```kotlin
+// SessionService — new
+fun persistSession() {
+    prefs.edit()
+        .putString("session_id", sessionId)
+        .putLong("session_start", sessionStartTime)
+        .putLong("last_active_timestamp", System.currentTimeMillis())
+        .apply()
+}
+```
+
+`total_sessions` is already persisted (`SessionService.kt:40-41`).
+
+#### 2. Move the session decision into `initialize()`
+
+`initialize()` currently mints unconditionally. Replace with **load-then-decide** (this is where
+the first `session.started` fires, at init step 15 — before any Activity `onStart`):
+
+```kotlin
+fun initialize() {
+    val savedId    = prefs.getString("session_id", null)
+    val lastActive = prefs.getLong("last_active_timestamp", 0L)
+    val withinTimeout = savedId != null &&
+        System.currentTimeMillis() - lastActive < config.sessionTimeoutMs
+
+    if (withinTimeout) {
+        // RESUME — silent continuation
+        sessionId        = savedId!!
+        sessionStartTime = prefs.getLong("session_start", System.currentTimeMillis())
+        totalSessions    = prefs.getInt("total_sessions", 1)     // no increment
+        resumed = true                                            // suppress session.started (step 15)
+    } else {
+        // NEW (or timed-out) session
+        timedOutOnInit = savedId != null                         // signals finalize below
+        sessionId        = idGenerator.generateSessionId()
+        sessionStartTime = System.currentTimeMillis()
+        totalSessions    = prefs.getInt("total_sessions", 0) + 1
+        prefs.edit().putInt("total_sessions", totalSessions).apply()
+    }
+    // Make the immediately-following first onStart a no-op:
+    prefs.edit().putLong("last_active_timestamp", System.currentTimeMillis()).apply()
+}
+```
+
+Writing `last_active = now` at the end means the first `onStart` after init sees `elapsed ≈ 0` →
+not timed out → the existing resume branch logs and does nothing. **No double-decision, no
+double-mint** — defect 1 fixed. Subsequent *warm* returns (background→foreground, same process) keep
+using the unchanged `onStart` path and rotate correctly with live in-memory stats.
+
+#### 3. Emission behavior
+
+- **Resume (within timeout):** emit **nothing** — silent continuation. `TelemetryManager` init step
+  15 (`:341-344`) checks `sessionService.wasResumed()` and **skips** `emitSessionStartedEvent()`.
+  The session-id continuity is the signal; the backend already saw the original `session.started`
+  from the prior process.
+- **Timed-out on init:** before minting, emit `session.finalized(session.reason = "timeout")` for
+  the old id with duration from persisted `session_start → last_active`. **Minimal stats only** —
+  in-memory counters (event/screen counts, `visited_screens`) died with the prior process; the
+  backend reconstructs real counts by grouping the event stream on `session_id`. Then emit
+  `session.started` for the new session (existing step-15 path).
+- **Warm timeout rotation** (`onStart`, same process): unchanged — `session.finalized` here carries
+  **accurate** live in-memory stats, then `session.started`.
+
+### Known limitation (accepted)
+
+A resumed session's in-memory counters restart at 0 in the new process, so client-side per-session
+counts under-report after any process death. This is inherent to resuming across death and is why
+post-death `session.finalized` is minimal — the backend is the source of truth for per-session
+aggregates.
+
+### Files touched (execution, downstream)
+
+| File | Change |
+|---|---|
+| `core/services/SessionService.kt` | load-then-decide `initialize()`; `persistSession()`; `wasResumed()` / `timedOutOnInit()` flags; expose persisted-derived duration for finalize |
+| `core/TelemetryManager.kt` | init step 15 skips `session.started` when resumed; emit `session.finalized(timeout, minimal)` when `timedOutOnInit`; `onStop` calls `persistSession()` (replaces bare `updateLastActiveTimestamp()`) |
+| `core/services/SessionServiceTest.kt` | tests below |
+
+### Failing tests
+
+```kotlin
+@Test fun `cold start after timeout mints exactly one session and increments total once`() { … }
+@Test fun `cold start within timeout resumes persisted id, no total increment, no session_started`() { … }
+@Test fun `timed-out cold start finalizes old id with reason=timeout before starting new`() { … }
+```
+
+The double-mint test fails today (two ids, `total_sessions += 2`); passes after the fix.
+
+---
+
+## Part 2 — Duplicate / timing-stealing `screen_view`
+
+### Problem — worse than "duplicate shape"
+
+`screen_view` is emitted from two places under one wire name:
+
+- **ungated**, on `onActivityPaused` (`TelemetryActivityLifecycleObserver.kt:71-79`) —
+  `{screen_name, duration_ms, session_id, timestamp}`.
+- **gated** (`enableLegacyScreenEvents`, default off) + `@Deprecated`, via
+  `recordScreenView()` (`TelemetryManager.kt:556-568`) — `{screen_name}` only. The deprecation text
+  states plainly: *"Legacy screen_view event is not supported by backend."*
+
+`ScreenTimingTracker.endScreen()` **removes** the entry it reads
+(`ScreenTimingTracker.kt` — `screenStartTimes.remove(...)`). Because `onActivityPaused` **always**
+precedes `onActivityStopped`, the pause path calls `endScreen` first and consumes the timing; the
+stop path's `endScreen` then returns **null**, so **`recordScreenDuration(...)` → `screen.duration`
+never fires on the normal Activity flow.** `screen.duration` is the *backend-supported* screen event
+(routed by `event_processor.py` → `rum_screen_durations`, carries `exit_method`). Today it is dead
+on the Activity path — starved by an unsupported event.
+
+### Decision
+
+**Retire `screen_view` entirely on Android.** No shape survives.
+
+1. **Delete the pause emission**, `TelemetryActivityLifecycleObserver.kt:68-80` (the
+   `endScreen` + `recordEvent("screen_view", …)` block). Keep `performanceTracker.stop()` in
+   `onActivityPaused` (leak prevention). `onActivityStopped` becomes the sole owner of `endScreen`
+   for the pause→stop flow → **`screen.duration` (with `exit_method`) revives.**
+2. **Delete `recordScreenView()`** (`TelemetryManager.kt:551-569`) and the
+   `enableLegacyScreenEvents` field (`TelemetryConfig.kt:16`) and its reader
+   (`TelemetryManager.kt:134`, `isLegacyScreenEventsEnabled`). Removes the last `screen_view`
+   emitter and the opt-in flag. Source-breaking for any consumer still calling the deprecated,
+   default-off method — acceptable at a conformance milestone (already `@Deprecated(WARNING)` and a
+   no-op for them by default). Drop the `enableLegacyScreenEvents` row from the CLAUDE.md opt-in
+   table.
+
+After this, screen lifecycle on Android is: `navigation` (entry, `onActivityResumed`) +
+`screen.duration` (exit, `onActivityStopped`/`Destroyed`/`SaveInstanceState`, with `exit_method`).
+Both backend-supported; no `screen_view` anywhere.
+
+### Files touched (execution, downstream)
+
+| File | Change |
+|---|---|
+| `core/TelemetryActivityLifecycleObserver.kt` | delete the `screen_view` emission block (`:68-80`); `onActivityStopped` owns `endScreen` |
+| `core/TelemetryManager.kt` | delete `recordScreenView()` (`:551-569`) and `isLegacyScreenEventsEnabled()` (`:134`) |
+| `core/TelemetryConfig.kt` | delete `enableLegacyScreenEvents` (`:16`) |
+| `CLAUDE.md` | remove the `enableLegacyScreenEvents` opt-in row |
+| test | assert `screen.duration` fires on a pause→stop cycle (fails today: pause steals the timing) |
+
+### Failing test
+
+```kotlin
+@Test fun `pause then stop emits screen_duration, never screen_view`() {
+    // drive onActivityPaused then onActivityStopped for one Activity
+    // assert: exactly one screen.duration event (with exit_method), zero screen_view events
+}
+```
+
+Fails today — pause fires `screen_view` and consumes the timing, so `screen.duration` never emits.
+
+---
+
+No wire-format coupling to the #30 envelope. Both parts are client-internal correctness; Part 2
+*removes* a wire name, Part 1 changes only session bookkeeping + the `session.finalized`/`started`
+firing conditions.

--- a/docs/specs/timestamp-correctness.md
+++ b/docs/specs/timestamp-correctness.md
@@ -1,0 +1,85 @@
+# Android spec: timestamp correctness — true UTC everywhere
+
+**Ticket:** [#41](https://github.com/NCG-Africa/edge_telemetry_android/issues/41) · **Map:** [#29](https://github.com/NCG-Africa/edge_telemetry_android/issues/29) · **Audit:** #5 · **Hub decision:** D6 (`edge_rum_spec` #1) · **Rides:** #30 envelope
+**Status:** spec (plan-only, no merged code)
+
+## Problem (audit #5, `sdk-audit.yaml:431-434`)
+
+One payload carries three incompatible time representations:
+
+1. **Fake UTC.** Every `SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US)` appends a literal `Z` but formats in the **device's default timezone** — no `setTimeZone(UTC)` exists anywhere in the module (verified: zero `setTimeZone`/`TimeZone`/`ZoneOffset` references). A device in UTC+3 emits `...T14:00:00Z` for an event that happened at 11:00 UTC. Server reads it as UTC → every non-UTC device is silently wrong by its offset.
+2. **True UTC, different precision.** The crash path and a few others use `Instant.now().toString()` — real UTC, but variable sub-second precision (nanos when present), so it never matches the `SimpleDateFormat` shape.
+3. **Raw epoch-ms ints.** Some attribute "timestamps" are `System.currentTimeMillis()` Longs, mixed into the same payload as the ISO strings above.
+
+Two extra defects surfaced while speccing:
+
+- **`SimpleDateFormat` is not thread-safe** and `TelemetryManager.dateFormat` (`TelemetryManager.kt:78`) is `public val`, read from IO/main/lifecycle threads (`TelemetryMemoryUsage`, emitters). Concurrent `format()` can produce garbage strings independent of the TZ bug.
+- **`Instant.now()` is an API-26 landmine.** `minSdk = 24` and core-library desugaring is **disabled** (`build.gradle.kts:52,126-127` commented out, "we no longer use Java 8 time APIs"). `java.time.Instant.now()` does not exist on API 24/25 → `NoSuchMethodError` at runtime. Live sites `NavigationStackTracker.kt:21/35/50`, `Breadcrumb.kt:26`, and the crash path (#39) will crash on Android 7.0/7.1 — a crash reporter that crashes while reporting a crash. This rules out "just migrate to `java.time`" unless desugaring is re-enabled.
+
+## Decisions
+
+### D-1 — One representation: millisecond-precision ISO-8601, true UTC
+
+Every point-in-time value on the wire — envelope `timestamp`, per-event `timestamp`, and every `*.timestamp` attribute — is the **same string**:
+
+```
+yyyy-MM-dd'T'HH:mm:ss.SSS'Z'   // UTC, e.g. 2026-07-16T09:41:00.123Z
+```
+
+- **Millisecond** precision (`.SSS`), fixed width — matches the #30 envelope example (`...:00.123Z`), deterministic to parse, drops `Instant`'s variable nanos.
+- Satisfies D6 ("true UTC"). No epoch-ms ints on the wire for anything named a timestamp.
+
+**Not a timestamp, stays numeric:** elapsed-duration fields (`*_ms` — `duration_ms`, `screen.duration_ms`, `http.duration_ms`, `latency_ms`) are spans, not clock points. They remain `Long`/`Double` millis. This decision only touches point-in-time values.
+
+### D-2 — One shared, thread-safe formatter; delete `Instant.now()`
+
+Add a single top-level helper (new file `core/TelemetryTime.kt`); every timestamp goes through it. No new dependency, no desugaring, no `java.time`.
+
+```kotlin
+object TelemetryTime {
+    private val fmt = ThreadLocal.withInitial {
+        SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US)
+            .apply { timeZone = TimeZone.getTimeZone("UTC") }   // the fix the other 7 sites all miss
+    }
+    fun now(): String = isoOf(System.currentTimeMillis())
+    fun isoOf(epochMs: Long): String = fmt.get()!!.format(Date(epochMs))
+}
+```
+
+- `ThreadLocal` makes `SimpleDateFormat` safe without locks (stdlib only, ponytail rung 2/4).
+- **Delete all 7 ad-hoc `SimpleDateFormat` fields** (`TelemetryManager.kt:78`, `BatchProcessingService.kt:37`, `CrashReportingService.kt:46`, `SessionService.kt:28`, `EventTrackingService.kt:12`, plus the inline `TrackComposeScreen.kt:52`) → call `TelemetryTime.now()`.
+- **Delete all `Instant.now().toString()`** → `TelemetryTime.now()`. Kills the API-26 crash landmine at `NavigationStackTracker.kt:21/35/50`, `Breadcrumb.kt:26`, and the crash rail (#39). (`Instant` sites in already-dead code — `JsonEventTracker`, `FlutterCompatiblePayload` — are deleted by #37, not re-touched here.)
+- Remove the now-unused `SimpleDateFormat`/`Instant`/`Date` imports the deletions strand.
+
+### D-3 — Attribute timestamp policy: convert to the same ISO string
+
+Point-in-time attributes standardize on D-1's ISO string via `TelemetryTime`:
+
+| Site | Now | After |
+|---|---|---|
+| `TelemetryManager.kt:755` `initialization_timestamp` | `System.currentTimeMillis()` (Long) | `TelemetryTime.now()` |
+| `MemoryTracker.kt:310` `memory.timestamp` | `System.currentTimeMillis()` (Long) | `TelemetryTime.now()` |
+| `TelemetryMemoryUsage.kt:57/151/224` `memory.timestamp`/`storage.timestamp` | `dateFormat.format(Date())` (fake-UTC) | `TelemetryTime.now()` |
+
+This also **fixes the `memory.timestamp` double-shape** (Long in `MemoryTracker` vs String in `TelemetryMemoryUsage`) — one emitter path, one type.
+`TelemetryActivityLifecycleObserver.kt:77`'s epoch-ms `timestamp` rides the `screen_view` event **already retired by #35** — no action, just don't reintroduce it.
+
+`MemoryEventInfo.timestamp` (`models/TelemetryBatch.kt:107`) is already `String` — model unchanged; the Long emitter was the mismatch.
+
+### D-4 — Guard: no naive-local formatting can come back
+
+Two cheap checks (ponytail: one runnable check per non-trivial decision):
+
+1. **Behavior test** (`src/test`, JUnit, no framework): feed `TelemetryTime.isoOf(0L)` → assert exactly `"1970-01-01T00:00:00.000Z"`; feed a known epoch → assert the fixed UTC string. Fails if the TZ or pattern regresses. One `@Test`.
+2. **Source guard test**: a JUnit test that greps `src/main` and **fails** if it finds `SimpleDateFormat(` outside `TelemetryTime.kt`, or any `Instant.now(`, or a `"…timestamp…" to System.currentTimeMillis()` attribute literal. Keeps the single-helper invariant enforced in CI (rides #31's `testDebugUnitTest` gate) without adding a detekt rule.
+
+## Scope / coordination
+
+- **In:** the 7 formatter sites, the `Instant.now()` live sites, the 3 attribute sites, `TelemetryTime.kt`, 2 tests.
+- Coordinates with **#40**: `http.timestamp` takes its value from `TelemetryTime.now()` (#40 explicitly deferred format to #41). **#39** crash rail: `error.timestamp`/event `timestamp` use the helper. **#30** envelope: the top-level/event `timestamp` this helper feeds is the D6 field #30 specified.
+- **No hub gap** — D6 is given; this is the android *how*.
+- **Not chosen:** epoch-ms-everywhere (rejected — #30 already fixed the envelope on ISO string; aligning attributes to ISO removes the mix, epoch-ms would re-introduce it) · re-enabling core-library desugaring for `java.time` (rejected — adds a build dep + `desugar_jdk_libs` for zero benefit over `TelemetryTime`; the repo deliberately removed it).
+
+## Out of scope → fog
+
+- **Monotonic vs wall-clock skew** — device clocks can be wrong/adjusted; a server-side `received_at` or monotonic correction is a backend/hub concern, not an android format decision. Flag to hub if drift proves material.

--- a/docs/specs/user-interaction-events.md
+++ b/docs/specs/user-interaction-events.md
@@ -1,0 +1,80 @@
+# Android spec: user-interaction events — `ui.interaction` (new datapoint)
+
+**Ticket:** [#42](https://github.com/NCG-Africa/edge_telemetry_android/issues/42) · **Map:** [#29](https://github.com/NCG-Africa/edge_telemetry_android/issues/29) · **Depends on:** [#30 unified envelope](https://github.com/NCG-Africa/edge_telemetry_android/issues/30) (closed)
+
+## Summary
+
+A net-new datapoint. `enableUserInteractionEvents` already exists (default `true`, `TelemetryConfig.kt:17`) but **nothing emits interaction events today**. This spec designs automatic capture of taps / long-presses / swipes and their wire shape on the unified envelope.
+
+One event: **`ui.interaction`**, discriminated by a `type` attribute. Rides the standard `recordEvent` → envelope path (`TelemetryManager.kt:472`), auto-enriched with `session.*` / `user.*` / `sdk.*`, batched (50). Plus a compact crash breadcrumb per interaction.
+
+Plan-only: this is a spec, not merged code.
+
+## Capture mechanism
+
+**View world — automatic.** In `TelemetryActivityLifecycleObserver.onActivityResumed(activity)` (`:36`), wrap the Activity's `Window.Callback` (`window.callback`) with a delegating wrapper that forwards every call to the original and additionally feeds `dispatchTouchEvent`'s `MotionEvent`s to a `GestureDetector`. Restore the original callback in `onActivityPaused(activity)` (`:61`) to avoid leaks and double-wrapping on re-resume. No permission, no per-View listener injection — the only approach that is both automatic and permission-free (rejected: AccessibilityService = heavy + user-granted permission; consumer-attached listeners = not automatic).
+
+`GestureDetector` collapses a raw `MotionEvent` stream into one callback per completed gesture:
+- `onSingleTapConfirmed` → `type = "tap"`
+- `onLongPress` → `type = "long_press"`
+- `onFling` → `type = "swipe"` (direction `up`/`down`/`left`/`right` from velocity sign/magnitude; emitted **once** at fling end)
+
+On a completed gesture, hit-test `activity.window.decorView` for the deepest View whose bounds contain the touch point and that carries an id (else its class) — that is the `target`.
+
+**Compose world — coordinate-only in v1.** Compose renders its whole tree inside one `AndroidComposeView`, so View-tree hit-testing resolves to that single view, not the composable. v1 accepts this: Compose taps still emit `{type, x, y, screen}` with `target = "compose_surface"`. **No reflection into Compose internals** (`SemanticsOwner` is private API — a version-fragility landmine). Per-composable identity graduates via an opt-in `Modifier.trackTap("tag")` (see fog).
+
+## Privacy — secure-surface suppression (bank-compliance requirement)
+
+Raw tap coordinates over an in-app numeric keypad / PIN pad / password field are a **keystroke-inference risk**: a sequence of `(x, y)` taps can reconstruct an entered PIN or password. Same class of leak as full-URL query strings in [#40](https://github.com/NCG-Africa/edge_telemetry_android/issues/40). Fogging content-desc does **not** cover this — the coordinates alone leak it.
+
+**Bound:** the system soft keyboard (IME) runs in a **separate window**, so the Activity's `Window.Callback` never sees IME taps. Exposure is **in-app surfaces only**.
+
+**Rule (decided here):** suppress `ui.interaction` capture — emit nothing — when the hit-tested target is a secure input surface:
+- an `EditText` (or subclass) whose `inputType` has a password variation (`TYPE_TEXT_VARIATION_PASSWORD`, `TYPE_TEXT_VARIATION_VISIBLE_PASSWORD`, `TYPE_TEXT_VARIATION_WEB_PASSWORD`, `TYPE_NUMBER_VARIATION_PASSWORD`), **or**
+- the view or its window carries `FLAG_SECURE`.
+
+This is a single check in the hit-test path. It is a **hard default, not a config flag** (a compliance control should not be switchable off).
+
+**Residual → flagged to the hub.** A *custom* in-app PIN pad built from plain `Button`/`View`s (no password `inputType`, no `FLAG_SECURE`) cannot be inferred by the SDK. Flagged to `edge_rum_spec` as a cross-SDK privacy rule (alongside #40's path-PII), same as content-desc: the SDK can only suppress surfaces it can *detect*. Consumers with custom keypads must set `FLAG_SECURE` on that screen (which they should anyway) to be covered.
+
+## Event shape
+
+`ui.interaction` attributes:
+
+| key | example | notes |
+|---|---|---|
+| `ui.type` | `tap` \| `long_press` \| `swipe` | discriminator |
+| `ui.target` | `checkout_button` | `getResourceEntryName(id)`; falls back to View class simple name (`MaterialButton`); `compose_surface` for Compose |
+| `ui.x` | `540` | raw pixel x |
+| `ui.y` | `1180` | raw pixel y |
+| `ui.direction` | `left` | swipe only; omitted for tap/long_press |
+| `ui.screen` | `CheckoutActivity` | from `NavigationStackTracker.getCurrentScreen()` (`:55`) — reuse the observer's existing tracker instance |
+
+**Never captured:** entered text, field values, content-description (fogged). Timestamp + `session.*`/`user.*`/`sdk.*` are added by standard enrichment; no per-event timestamp field of its own beyond the envelope's.
+
+## Delivery
+
+- **Full event** via `telemetryManager.recordEvent("ui.interaction", attrs)` — standard envelope (#30) path, batched (50), no special rail.
+- **Plus a compact breadcrumb** per interaction (`addBreadcrumb("tap checkout_button", category = "ui")`). Interactions are the highest-value crash-context trail ("what did the user tap before the crash"). The `BreadcrumbManager` 50-cap eviction is **correct here** — recent taps are what crash triage wants; evicting stale crumbs is the circular buffer's job.
+
+## Volume / sampling
+
+Gesture-completion **is** the dedup: `GestureDetector` emits once per gesture, never per raw `MotionEvent`, bounding volume to human tapping speed (~1–3/s, hundreds/session) — nothing like the per-frame flood #36 fought. **No sampling in v1.** Distinct consecutive taps are not deduped (they are real interactions).
+
+## v1 scope boundary
+
+**In:** `{tap, long_press, swipe}`, View-world automatic target identity, Compose coordinate-only, secure-surface suppression.
+
+**Out (→ fog / hub):**
+- opt-in `Modifier.trackTap("tag")` for per-composable Compose identity
+- content-description as a target identifier (PII-sanitization burden)
+- normalized (0–1) coordinates for cross-device heatmaps
+- `scroll`/`drag` and `double-tap` gestures
+- custom-keypad PII rule → flagged to `edge_rum_spec` hub
+
+## Test plan
+
+- Behavior: instrument an Activity, dispatch a synthetic tap on a view with a known id → assert one `ui.interaction` with `type=tap`, matching `ui.target`.
+- Privacy: dispatch a tap on a password `EditText` and on a `FLAG_SECURE` view → assert **no** event emitted.
+- Swipe: synthetic fling → `type=swipe` with correct `ui.direction`, exactly one event.
+- Dedup: a drag (multiple move events) ending in a fling → exactly one `swipe` event, zero per-move events.


### PR DESCRIPTION
## Summary

Lands the EdgeRUM conformance execution handoff on `master`:

- **Execution specs** — 14 `docs/specs/*.md` implementation specs rolling the closed planning map (#29) into buildable tickets, plus the `sdk-audit.yaml` wire-format ground truth. (Envelope + network-schema specs already merged in #30/#40.)
- **Claude worker** — `.github/workflows/claude-worker.yml` auto-implements a ticket when labeled **`ready-for-agent`**, gated on native GitHub blocking (`issue_dependencies_summary.blocked_by == 0` → run).

## Why merge to master

The worker runs on `issues: labeled` events, which GitHub executes from the **default branch**. The `ready-for-agent` trigger is inert until this is on `master`.

## Tickets

Execution PRD #45 was decomposed into 16 tickets (#47–#62) via `/to-tickets`, wired with native blocking edges. Frontier (0 blockers): #47–#55.

## Note

The 16 tickets already carry `ready-for-agent`, applied before the trigger existed on the default branch — they won't auto-fire retroactively. After merge, re-apply the label (remove + add) on a frontier ticket to kick the worker.
