### PR TITLE
ci: grant id-token:write to claude worker

### DIFF
--- a/.github/workflows/claude-worker.yml
+++ b/.github/workflows/claude-worker.yml
@@ -45,6 +45,7 @@ jobs:
       contents: write
       issues: write
       pull-requests: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Frontier ticket #47 dispatched `/implement` but the action failed with `Could not fetch an OIDC token`. `anthropics/claude-code-action@v1` needs `id-token: write`; the implement job only granted contents/issues/pull-requests. Adds the missing permission.