### PR TITLE
ci: grant claude worker the tools to implement + open a PR

### DIFF
--- a/.github/workflows/claude-worker.yml
+++ b/.github/workflows/claude-worker.yml
@@ -53,7 +53,7 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--max-turns 25 --model sonnet"
+          claude_args: '--max-turns 25 --model sonnet --allowedTools "Edit,Write,Read,Glob,Grep,Bash"'
           prompt: |
             /implement ticket #${{ github.event.issue.number }}. Work only this
             ticket's scope. Branch issue-${{ github.event.issue.number }}. Open a

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@
 .cxx
 local.properties
 /.idea
+
+node_modules/

--- a/.sandcastle/.env.example
+++ b/.sandcastle/.env.example
@@ -1,0 +1,9 @@
+# Claude Code OAuth token — get one by running `claude setup-token` on your host.
+# Lets the agent use your Claude subscription instead of an API key.
+CLAUDE_CODE_OAUTH_TOKEN=
+# Or use an Anthropic API key instead — uncomment and fill in:
+# ANTHROPIC_API_KEY=
+# GitHub personal access token — the agent uses it to read and manage GitHub Issues
+# Create a fine-grained token: https://github.com/settings/personal-access-tokens/new
+# Required repository permissions: Issues (Read and write) and Metadata (Read)
+GH_TOKEN=

--- a/.sandcastle/.gitignore
+++ b/.sandcastle/.gitignore
@@ -1,0 +1,3 @@
+.env
+logs/
+worktrees/

--- a/.sandcastle/Dockerfile
+++ b/.sandcastle/Dockerfile
@@ -1,0 +1,39 @@
+FROM node:22-bookworm
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+  git \
+  curl \
+  jq \
+  && rm -rf /var/lib/apt/lists/*
+
+# Install GitHub CLI
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+  | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+  | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+  && apt-get update && apt-get install -y gh \
+  && rm -rf /var/lib/apt/lists/*
+
+# Build-args for UID/GID alignment: sandcastle docker build-image
+# defaults these to the host user's UID/GID so image-built files
+# and bind-mounted files share an owner without runtime chown.
+ARG AGENT_UID=1000
+ARG AGENT_GID=1000
+
+# Rename the base image's "node" user to "agent" and align UID/GID.
+RUN groupmod -o -g $AGENT_GID node && usermod -o -u $AGENT_UID -g $AGENT_GID -d /home/agent -m -l agent node
+USER ${AGENT_UID}:${AGENT_GID}
+
+# Install Claude Code CLI
+RUN curl -fsSL https://claude.ai/install.sh | bash
+
+# Add Claude to PATH
+ENV PATH="/home/agent/.local/bin:$PATH"
+
+WORKDIR /home/agent
+
+# In worktree sandbox mode, Sandcastle bind-mounts the git worktree at /home/agent/workspace
+# and overrides the working directory to /home/agent/workspace at container start.
+# Structure your Dockerfile so that /home/agent/workspace can serve as the project root.
+ENTRYPOINT ["sleep", "infinity"]

--- a/.sandcastle/main.mts
+++ b/.sandcastle/main.mts
@@ -1,0 +1,33 @@
+import { run, claudeCode } from "@ai-hero/sandcastle";
+import { docker } from "@ai-hero/sandcastle/sandboxes/docker";
+
+// Simple loop: an agent that picks open issues one by one and closes them.
+// Run this with: npx tsx .sandcastle/main.mts
+// Or add to package.json scripts: "sandcastle": "npx tsx .sandcastle/main.mts"
+
+await run({
+  // A name for this run, shown as a prefix in log output.
+  name: "worker",
+
+  // Sandbox provider — runs the agent inside an isolated container.
+  sandbox: docker(),
+
+  // The agent provider. Pass a model string to claudeCode() — sonnet balances
+  // capability and speed for most tasks. Switch to claude-opus-4-8 for harder
+  // problems, or claude-haiku-4-5-20251001 for speed.
+  agent: claudeCode("claude-opus-4-8"),
+
+  // Path to the prompt file. Shell expressions inside are evaluated inside the
+  // sandbox at the start of each iteration, so the agent always sees fresh data.
+  promptFile: "./.sandcastle/prompt.md",
+
+  // Maximum number of iterations (agent invocations) to run in a session.
+  // Each iteration works on a single issue. Increase this to process more issues
+  // per run, or set it to 1 for a single-shot mode.
+  maxIterations: 1,
+
+  // Branch strategy — 'branch' lands commits on a scratch branch and leaves the
+  // host HEAD untouched. The agent pushes its own issue-<ID> branches and opens
+  // PRs, so we don't want the run merging anything back to HEAD as well.
+  branchStrategy: { type: "branch", branch: "sandcastle-worker" },
+});

--- a/.sandcastle/prompt.md
+++ b/.sandcastle/prompt.md
@@ -1,0 +1,54 @@
+# Context
+
+## Open issues
+
+!`gh issue list --state open --label ready-for-agent --limit 100 --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'`
+
+The list above has already been filtered to issues ready for work and is the sole source of truth for what work exists. Do not run your own unfiltered query to find more issues — if the list is empty, there is nothing to do.
+
+## Recent mktowett commits (last 10)
+
+!`git log --oneline --grep="mktowett" -10`
+
+# Task
+
+You are mktowett — an autonomous coding agent working through issues one at a time.
+
+## Priority order
+
+Work on issues in this order:
+
+1. **Bug fixes** — broken behaviour affecting users
+2. **Tracer bullets** — thin end-to-end slices that prove an approach works
+3. **Polish** — improving existing functionality (error messages, UX, docs)
+4. **Refactors** — internal cleanups with no user-visible change
+
+Pick the highest-priority open issue that is not blocked by another open issue.
+
+## Workflow
+
+1. **Explore** — read the issue carefully. Pull in the parent PRD if referenced. Read the relevant source files and tests before writing any code.
+2. **Plan** — decide what to change and why. Keep the change as small as possible.
+3. **Execute** — use RGR (Red → Green → Repeat → Refactor): write a failing test first, then write the implementation to pass it.
+4. **Verify** — run `npm run typecheck` and `npm run test` before committing. Fix any failures before proceeding.
+5. **Commit** — make a single git commit. The message MUST:
+   - Start with `mktowett:` prefix
+   - Include the task completed and any PRD reference
+   - List key decisions made
+   - List files changed
+   - Note any blockers for the next iteration
+6. **Close** — close the issue with `gh issue close <ID> --comment "Completed by mktowett"` explaining what was done.
+
+## Rules
+
+- One branch + one PR per issue. Never commit directly to main.
+- Work on **one issue per iteration**. Do not attempt multiple issues in a single iteration.
+- Do not close an issue until you have committed the fix and verified tests pass.
+- Do not leave commented-out code or TODO comments in committed code.
+- If you are blocked (missing context, failing tests you cannot fix, external dependency), leave a comment on the issue and move on — do not close it.
+
+# Done
+
+When all actionable issues are complete (or you are blocked on all remaining ones), or the open-issues block at the top of this prompt is empty, output the completion signal:
+
+<promise>COMPLETE</promise>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,101 @@
+{
+  "name": "edge_telemetry_android",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "devDependencies": {
+        "@ai-hero/sandcastle": "^0.12.0"
+      }
+    },
+    "node_modules/@ai-hero/sandcastle": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@ai-hero/sandcastle/-/sandcastle-0.12.0.tgz",
+      "integrity": "sha512-kdQ414rM8t1QiWeqZ3Klz4KSd0PqQG4bRVuqGpRDUomWhojSZkEAc1tbcEcThVmBEaHkCt8LmYR49vqEPNIoYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@clack/prompts": "^1.1.0"
+      },
+      "bin": {
+        "sandcastle": "dist/main.js"
+      },
+      "peerDependencies": {
+        "@daytona/sdk": "^0.164.0",
+        "@vercel/sandbox": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@daytona/sdk": {
+          "optional": true
+        },
+        "@vercel/sandbox": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@clack/core": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@clack/core/-/core-1.4.3.tgz",
+      "integrity": "sha512-/kr3UWNtdJfxZtPgDqUOmG2pvwlmcLGheex5yiZKdwbzZJxhV+HMNR9QNmyY5cGwTNV6LrR7Jtp+KjhUAP1qBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-wrap-ansi": "^0.2.0",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 20.12.0"
+      }
+    },
+    "node_modules/@clack/prompts": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.7.0.tgz",
+      "integrity": "sha512-y7/yvZ2TPAnR9+jnc00klvNNLkJiXFFrQA/hlLCcxA9a2A4zQIOimyFQ9XfwYKiGD1fb5GY8vbKIIgO8d5Tb2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@clack/core": "1.4.3",
+        "fast-string-width": "^3.0.2",
+        "fast-wrap-ansi": "^0.2.0",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 20.12.0"
+      }
+    },
+    "node_modules/fast-string-truncated-width": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+      "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-string-width": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+      "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-truncated-width": "^3.0.2"
+      }
+    },
+    "node_modules/fast-wrap-ansi": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz",
+      "integrity": "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-width": "^3.0.2"
+      }
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "devDependencies": {
+    "@ai-hero/sandcastle": "^0.12.0"
+  }
+}


### PR DESCRIPTION
Worker reached the model but hit `permission_denials_count: 10` — v1's default allowlist blocks `Bash`, so every git/gh/gradlew call was denied; the model made no edits and opened no PR despite exiting success. Grants `Edit,Write,Read,Glob,Grep,Bash` via `--allowedTools`. Auth (OAuth token) and `--model sonnet` unchanged — both already work.