### PR TITLE
mktowett: Timestamp correctness — ISO-8601 true-UTC TelemetryTime helper (#49)

### DIFF
--- a/.github/workflows/claude-worker.yml
+++ b/.github/workflows/claude-worker.yml
@@ -53,7 +53,7 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--max-turns 25 --model sonnet"
+          claude_args: '--max-turns 25 --model sonnet --allowedTools "Edit,Write,Read,Glob,Grep,Bash"'
           prompt: |
             /implement ticket #${{ github.event.issue.number }}. Work only this
             ticket's scope. Branch issue-${{ github.event.issue.number }}. Open a

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@
 .cxx
 local.properties
 /.idea
+
+node_modules/

--- a/.sandcastle/.env.example
+++ b/.sandcastle/.env.example
@@ -1,0 +1,9 @@
+# Claude Code OAuth token — get one by running `claude setup-token` on your host.
+# Lets the agent use your Claude subscription instead of an API key.
+CLAUDE_CODE_OAUTH_TOKEN=
+# Or use an Anthropic API key instead — uncomment and fill in:
+# ANTHROPIC_API_KEY=
+# GitHub personal access token — the agent uses it to read and manage GitHub Issues
+# Create a fine-grained token: https://github.com/settings/personal-access-tokens/new
+# Required repository permissions: Issues (Read and write) and Metadata (Read)
+GH_TOKEN=

--- a/.sandcastle/.gitignore
+++ b/.sandcastle/.gitignore
@@ -1,0 +1,3 @@
+.env
+logs/
+worktrees/

--- a/.sandcastle/Dockerfile
+++ b/.sandcastle/Dockerfile
@@ -1,0 +1,39 @@
+FROM node:22-bookworm
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+  git \
+  curl \
+  jq \
+  && rm -rf /var/lib/apt/lists/*
+
+# Install GitHub CLI
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+  | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+  | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+  && apt-get update && apt-get install -y gh \
+  && rm -rf /var/lib/apt/lists/*
+
+# Build-args for UID/GID alignment: sandcastle docker build-image
+# defaults these to the host user's UID/GID so image-built files
+# and bind-mounted files share an owner without runtime chown.
+ARG AGENT_UID=1000
+ARG AGENT_GID=1000
+
+# Rename the base image's "node" user to "agent" and align UID/GID.
+RUN groupmod -o -g $AGENT_GID node && usermod -o -u $AGENT_UID -g $AGENT_GID -d /home/agent -m -l agent node
+USER ${AGENT_UID}:${AGENT_GID}
+
+# Install Claude Code CLI
+RUN curl -fsSL https://claude.ai/install.sh | bash
+
+# Add Claude to PATH
+ENV PATH="/home/agent/.local/bin:$PATH"
+
+WORKDIR /home/agent
+
+# In worktree sandbox mode, Sandcastle bind-mounts the git worktree at /home/agent/workspace
+# and overrides the working directory to /home/agent/workspace at container start.
+# Structure your Dockerfile so that /home/agent/workspace can serve as the project root.
+ENTRYPOINT ["sleep", "infinity"]

--- a/.sandcastle/main.mts
+++ b/.sandcastle/main.mts
@@ -1,0 +1,33 @@
+import { run, claudeCode } from "@ai-hero/sandcastle";
+import { docker } from "@ai-hero/sandcastle/sandboxes/docker";
+
+// Simple loop: an agent that picks open issues one by one and closes them.
+// Run this with: npx tsx .sandcastle/main.mts
+// Or add to package.json scripts: "sandcastle": "npx tsx .sandcastle/main.mts"
+
+await run({
+  // A name for this run, shown as a prefix in log output.
+  name: "worker",
+
+  // Sandbox provider — runs the agent inside an isolated container.
+  sandbox: docker(),
+
+  // The agent provider. Pass a model string to claudeCode() — sonnet balances
+  // capability and speed for most tasks. Switch to claude-opus-4-8 for harder
+  // problems, or claude-haiku-4-5-20251001 for speed.
+  agent: claudeCode("claude-opus-4-8"),
+
+  // Path to the prompt file. Shell expressions inside are evaluated inside the
+  // sandbox at the start of each iteration, so the agent always sees fresh data.
+  promptFile: "./.sandcastle/prompt.md",
+
+  // Maximum number of iterations (agent invocations) to run in a session.
+  // Each iteration works on a single issue. Increase this to process more issues
+  // per run, or set it to 1 for a single-shot mode.
+  maxIterations: 1,
+
+  // Branch strategy — 'branch' lands commits on a scratch branch and leaves the
+  // host HEAD untouched. The agent pushes its own issue-<ID> branches and opens
+  // PRs, so we don't want the run merging anything back to HEAD as well.
+  branchStrategy: { type: "branch", branch: "sandcastle-worker" },
+});

--- a/.sandcastle/prompt.md
+++ b/.sandcastle/prompt.md
@@ -1,0 +1,54 @@
+# Context
+
+## Open issues
+
+!`gh issue list --state open --label ready-for-agent --limit 100 --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'`
+
+The list above has already been filtered to issues ready for work and is the sole source of truth for what work exists. Do not run your own unfiltered query to find more issues — if the list is empty, there is nothing to do.
+
+## Recent mktowett commits (last 10)
+
+!`git log --oneline --grep="mktowett" -10`
+
+# Task
+
+You are mktowett — an autonomous coding agent working through issues one at a time.
+
+## Priority order
+
+Work on issues in this order:
+
+1. **Bug fixes** — broken behaviour affecting users
+2. **Tracer bullets** — thin end-to-end slices that prove an approach works
+3. **Polish** — improving existing functionality (error messages, UX, docs)
+4. **Refactors** — internal cleanups with no user-visible change
+
+Pick the highest-priority open issue that is not blocked by another open issue.
+
+## Workflow
+
+1. **Explore** — read the issue carefully. Pull in the parent PRD if referenced. Read the relevant source files and tests before writing any code.
+2. **Plan** — decide what to change and why. Keep the change as small as possible.
+3. **Execute** — use RGR (Red → Green → Repeat → Refactor): write a failing test first, then write the implementation to pass it.
+4. **Verify** — run `npm run typecheck` and `npm run test` before committing. Fix any failures before proceeding.
+5. **Commit** — make a single git commit. The message MUST:
+   - Start with `mktowett:` prefix
+   - Include the task completed and any PRD reference
+   - List key decisions made
+   - List files changed
+   - Note any blockers for the next iteration
+6. **Close** — close the issue with `gh issue close <ID> --comment "Completed by mktowett"` explaining what was done.
+
+## Rules
+
+- One branch + one PR per issue. Never commit directly to main.
+- Work on **one issue per iteration**. Do not attempt multiple issues in a single iteration.
+- Do not close an issue until you have committed the fix and verified tests pass.
+- Do not leave commented-out code or TODO comments in committed code.
+- If you are blocked (missing context, failing tests you cannot fix, external dependency), leave a comment on the issue and move on — do not close it.
+
+# Done
+
+When all actionable issues are complete (or you are blocked on all remaining ones), or the open-issues block at the top of this prompt is empty, output the completion signal:
+
+<promise>COMPLETE</promise>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,101 @@
+{
+  "name": "edge_telemetry_android",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "devDependencies": {
+        "@ai-hero/sandcastle": "^0.12.0"
+      }
+    },
+    "node_modules/@ai-hero/sandcastle": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@ai-hero/sandcastle/-/sandcastle-0.12.0.tgz",
+      "integrity": "sha512-kdQ414rM8t1QiWeqZ3Klz4KSd0PqQG4bRVuqGpRDUomWhojSZkEAc1tbcEcThVmBEaHkCt8LmYR49vqEPNIoYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@clack/prompts": "^1.1.0"
+      },
+      "bin": {
+        "sandcastle": "dist/main.js"
+      },
+      "peerDependencies": {
+        "@daytona/sdk": "^0.164.0",
+        "@vercel/sandbox": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@daytona/sdk": {
+          "optional": true
+        },
+        "@vercel/sandbox": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@clack/core": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@clack/core/-/core-1.4.3.tgz",
+      "integrity": "sha512-/kr3UWNtdJfxZtPgDqUOmG2pvwlmcLGheex5yiZKdwbzZJxhV+HMNR9QNmyY5cGwTNV6LrR7Jtp+KjhUAP1qBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-wrap-ansi": "^0.2.0",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 20.12.0"
+      }
+    },
+    "node_modules/@clack/prompts": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.7.0.tgz",
+      "integrity": "sha512-y7/yvZ2TPAnR9+jnc00klvNNLkJiXFFrQA/hlLCcxA9a2A4zQIOimyFQ9XfwYKiGD1fb5GY8vbKIIgO8d5Tb2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@clack/core": "1.4.3",
+        "fast-string-width": "^3.0.2",
+        "fast-wrap-ansi": "^0.2.0",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 20.12.0"
+      }
+    },
+    "node_modules/fast-string-truncated-width": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+      "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-string-width": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+      "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-truncated-width": "^3.0.2"
+      }
+    },
+    "node_modules/fast-wrap-ansi": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz",
+      "integrity": "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-width": "^3.0.2"
+      }
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "devDependencies": {
+    "@ai-hero/sandcastle": "^0.12.0"
+  }
+}

--- a/telemetry_library/src/main/java/com/androidtel/telemetry_library/compose/EdgeTelemetryCompose.kt
+++ b/telemetry_library/src/main/java/com/androidtel/telemetry_library/compose/EdgeTelemetryCompose.kt
@@ -11,7 +11,7 @@ import androidx.navigation.NavController
 import androidx.navigation.compose.currentBackStackEntryAsState
 import com.androidtel.telemetry_library.EdgeTelemetry
 import com.androidtel.telemetry_library.core.navigation.NavigationStackTracker
-import java.time.Instant
+import com.androidtel.telemetry_library.core.TelemetryTime
 
 /**
  * Enhanced Compose integration for EdgeTelemetry that provides automatic navigation tracking
@@ -113,7 +113,7 @@ fun TrackComposeScreen(
                 "route" to route,
                 "exit_method" to "navigation",
                 "duration_ms" to duration.toString(),
-                "timestamp" to Instant.now().toString()
+                "timestamp" to TelemetryTime.now()
             )
 
             // Add exit breadcrumb
@@ -163,7 +163,7 @@ fun TrackScreen(
             "screen" to screenName,
             "category" to category,
             "type" to "screen_entry",
-            "timestamp" to Instant.now().toString()
+            "timestamp" to TelemetryTime.now()
         )
         attributes?.let { entryData.putAll(it) }
         
@@ -213,7 +213,7 @@ fun TrackScreen(
                 "screen" to screenName,
                 "category" to category,
                 "duration_ms" to duration.toString(),
-                "timestamp" to Instant.now().toString()
+                "timestamp" to TelemetryTime.now()
             )
             attributes?.let { exitData.putAll(it) }
             
@@ -250,7 +250,7 @@ fun trackUserInteraction(
     val interactionData = mutableMapOf<String, String>(
         "action" to action,
         "target" to target,
-        "timestamp" to Instant.now().toString()
+        "timestamp" to TelemetryTime.now()
     )
     attributes?.let { interactionData.putAll(it) }
     
@@ -286,7 +286,7 @@ fun trackComposePerformance(
         "metric" to metricName,
         "value" to value.toString(),
         "unit" to unit,
-        "timestamp" to Instant.now().toString()
+        "timestamp" to TelemetryTime.now()
     )
     attributes?.let { performanceData.putAll(it) }
     

--- a/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/MemoryTracker.kt
+++ b/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/MemoryTracker.kt
@@ -307,7 +307,7 @@ private fun createStandardizedMemoryEvent(
         "memory.under_system_pressure" to isUnderPressure,
         "memory.api_level" to Build.VERSION.SDK_INT,
         "memory.tracking_method" to trackingMethod,
-        "memory.timestamp" to System.currentTimeMillis()
+        "memory.timestamp" to TelemetryTime.now()
     )
     
     // Basic heap memory (available in all implementations)

--- a/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/TelemetryManager.kt
+++ b/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/TelemetryManager.kt
@@ -48,9 +48,6 @@ import java.io.File
 import java.io.PrintWriter
 import java.io.StringWriter
 import java.security.SecureRandom
-import java.text.SimpleDateFormat
-import java.util.Date
-import java.util.Locale
 import java.util.UUID
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.Executors
@@ -75,7 +72,6 @@ class TelemetryManager private constructor(
     val applicationContext: Context get() = context
 
     private val scope = CoroutineScope(Dispatchers.IO)
-    val dateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US)
 
     // Pre-init call queue
     private val isReady = AtomicBoolean(false)
@@ -580,7 +576,7 @@ class TelemetryManager private constructor(
                 "navigation.method" to "push",
                 "navigation.route_type" to "compose_route",
                 "navigation.has_arguments" to false,
-                "navigation.timestamp" to dateFormat.format(Date())
+                "navigation.timestamp" to TelemetryTime.now()
             )
         )
     }
@@ -606,7 +602,7 @@ class TelemetryManager private constructor(
                 "screen.name" to screenName,
                 "screen.duration_ms" to durationMs,
                 "screen.exit_method" to exitMethod,
-                "screen.timestamp" to dateFormat.format(Date())
+                "screen.timestamp" to TelemetryTime.now()
             )
         )
     }
@@ -752,7 +748,7 @@ class TelemetryManager private constructor(
                     "device_capabilities" to capabilitySummary,
                     "network_capabilities" to networkSummary,
                     "memory_status" to memorySummary,
-                    "initialization_timestamp" to System.currentTimeMillis()
+                    "initialization_timestamp" to TelemetryTime.now()
                 )
             )
             
@@ -816,7 +812,7 @@ class TelemetryManager private constructor(
     /*    private fun getSessionInfo(): SessionInfo {
             return SessionInfo(
                 sessionId = sessionId,
-                startTime = dateFormat.format(Date(sessionStartTime))
+                startTime = TelemetryTime.isoOf(sessionStartTime)
             )
         }*/
 
@@ -893,7 +889,7 @@ class TelemetryManager private constructor(
             put("user.name", name ?: "")
             put("user.email", email ?: "")
             put("user.phone", phone ?: "")
-            put("user.profile_updated_at", dateFormat.format(Date()))
+            put("user.profile_updated_at", TelemetryTime.now())
         }
         recordEvent(eventName = "user.profile.update", attributes = attributes)
     }

--- a/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/TelemetryMemoryUsage.kt
+++ b/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/TelemetryMemoryUsage.kt
@@ -2,7 +2,6 @@ package com.androidtel.telemetry_library.core
 
 import android.os.Build
 import android.util.Log
-import java.util.Date
 
 /**
  * Enhanced memory usage tracking with API-level appropriate methods.
@@ -54,7 +53,7 @@ class TelemetryMemoryUsage(private val telemetryManager: TelemetryManager = Tele
             
             // Calculate enhanced pressure level
             val pressureLevel = calculateEnhancedPressureLevel(memorySummary, isUnderPressure)
-            val timestamp = telemetryManager.dateFormat.format(Date())
+            val timestamp = TelemetryTime.now()
             
             // Record comprehensive memory event
             val memoryAttributes = mutableMapOf<String, Any>(
@@ -148,7 +147,7 @@ class TelemetryMemoryUsage(private val telemetryManager: TelemetryManager = Tele
                 else -> "high"
             }
             
-            val timestamp = telemetryManager.dateFormat.format(Date())
+            val timestamp = TelemetryTime.now()
             
             // Record basic memory event (only if enabled)
             if (telemetryManager.isMemoryTrackingEnabled()) {
@@ -221,7 +220,7 @@ class TelemetryMemoryUsage(private val telemetryManager: TelemetryManager = Tele
         memoryCapabilityTracker?.let { tracker ->
             try {
                 val storageInfo = tracker.getStorageInfo()
-                val timestamp = telemetryManager.dateFormat.format(Date())
+                val timestamp = TelemetryTime.now()
                 
                 val storageAttributes = mutableMapOf<String, Any>(
                     "storage.timestamp" to timestamp,

--- a/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/TelemetryTime.kt
+++ b/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/TelemetryTime.kt
@@ -1,0 +1,30 @@
+package com.androidtel.telemetry_library.core
+
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.TimeZone
+
+/**
+ * Single, thread-safe source of truth for point-in-time timestamps on the wire.
+ *
+ * Every timestamp the SDK emits — envelope `timestamp`, per-event `timestamp`, and every
+ * `*.timestamp` attribute — is a millisecond-precision ISO-8601 string in true UTC
+ * (`yyyy-MM-dd'T'HH:mm:ss.SSS'Z'`, e.g. `2026-07-16T09:41:00.123Z`).
+ *
+ * Uses a [ThreadLocal] [SimpleDateFormat] so formatting is safe without locks — [SimpleDateFormat]
+ * is not thread-safe. Stdlib only: no `java.time` (which crashes on the SDK's min-SDK 24/25 without
+ * core-library desugaring) and no new dependency.
+ */
+object TelemetryTime {
+    private val fmt = ThreadLocal.withInitial {
+        SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US)
+            .apply { timeZone = TimeZone.getTimeZone("UTC") }
+    }
+
+    /** Current wall-clock instant as a true-UTC ISO-8601 millisecond string. */
+    fun now(): String = isoOf(System.currentTimeMillis())
+
+    /** Convert an epoch-millisecond value to the same true-UTC ISO-8601 millisecond string. */
+    fun isoOf(epochMs: Long): String = fmt.get()!!.format(Date(epochMs))
+}

--- a/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/TrackComposeScreen.kt
+++ b/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/TrackComposeScreen.kt
@@ -49,7 +49,7 @@ fun TrackComposeScreen(
                 "navigation.method" to "push",
                 "navigation.route_type" to "compose_route",
                 "navigation.has_arguments" to (additionalData != null),
-                "navigation.timestamp" to java.text.SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", java.util.Locale.US).format(java.util.Date())
+                "navigation.timestamp" to TelemetryTime.now()
             )
         )
         

--- a/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/breadcrumbs/Breadcrumb.kt
+++ b/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/breadcrumbs/Breadcrumb.kt
@@ -1,6 +1,6 @@
 package com.androidtel.telemetry_library.core.breadcrumbs
 
-import java.time.Instant
+import com.androidtel.telemetry_library.core.TelemetryTime
 
 /**
  * Breadcrumb data structure matching Flutter SDK format
@@ -23,7 +23,7 @@ data class Breadcrumb(
                 message = message,
                 category = category,
                 level = level,
-                timestamp = Instant.now().toString(),
+                timestamp = TelemetryTime.now(),
                 data = data
             )
         }

--- a/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/navigation/NavigationStackTracker.kt
+++ b/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/navigation/NavigationStackTracker.kt
@@ -1,6 +1,6 @@
 package com.androidtel.telemetry_library.core.navigation
 
-import java.time.Instant
+import com.androidtel.telemetry_library.core.TelemetryTime
 import java.util.ArrayDeque
 import java.util.concurrent.locks.ReentrantReadWriteLock
 import kotlin.concurrent.read
@@ -18,7 +18,7 @@ class NavigationStackTracker {
                 fromScreen = fromScreen,
                 toScreen = screenName,
                 method = NavigationMethod.PUSH,
-                timestamp = Instant.now().toString()
+                timestamp = TelemetryTime.now()
             )
         }
     }
@@ -32,7 +32,7 @@ class NavigationStackTracker {
                 fromScreen = fromScreen,
                 toScreen = toScreen,
                 method = NavigationMethod.POP,
-                timestamp = Instant.now().toString()
+                timestamp = TelemetryTime.now()
             )
         }
     }
@@ -47,7 +47,7 @@ class NavigationStackTracker {
                 fromScreen = fromScreen,
                 toScreen = screenName,
                 method = NavigationMethod.REPLACE,
-                timestamp = Instant.now().toString()
+                timestamp = TelemetryTime.now()
             )
         }
     }

--- a/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/services/BatchProcessingService.kt
+++ b/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/services/BatchProcessingService.kt
@@ -10,9 +10,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import java.text.SimpleDateFormat
-import java.util.Date
-import java.util.Locale
+import com.androidtel.telemetry_library.core.TelemetryTime
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService
@@ -34,7 +32,6 @@ internal class BatchProcessingService(
     private val offlineStorage: OfflineBatchStorage,
     private val scope: CoroutineScope
 ) {
-    private val dateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US)
     private var flushTimer: ScheduledExecutorService? = null
     private var batchSendJob: Job? = null
     
@@ -94,7 +91,7 @@ internal class BatchProcessingService(
         
         val batch = TelemetryBatch(
             batchSize = eventsToSend.size,
-            timestamp = dateFormat.format(Date()),
+            timestamp = TelemetryTime.now(),
             events = eventsToSend,
             location = location
         )
@@ -178,7 +175,7 @@ internal class BatchProcessingService(
             if (eventsToStore.isNotEmpty()) {
                 val batch = TelemetryBatch(
                     batchSize = eventsToStore.size,
-                    timestamp = dateFormat.format(Date()),
+                    timestamp = TelemetryTime.now(),
                     events = eventsToStore
                 )
                 offlineStorage.storeBatch(batch)

--- a/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/services/CrashReportingService.kt
+++ b/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/services/CrashReportingService.kt
@@ -17,9 +17,7 @@ import kotlinx.coroutines.launch
 import java.io.File
 import java.io.PrintWriter
 import java.io.StringWriter
-import java.text.SimpleDateFormat
-import java.util.Date
-import java.util.Locale
+import com.androidtel.telemetry_library.core.TelemetryTime
 
 /**
  * CrashReportingService - Handles crash and error reporting
@@ -43,7 +41,6 @@ internal class CrashReportingService(
     private val telemetryEndpoint: String
 ) {
     private val gson = Gson()
-    private val dateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US)
     
     private var crashReporter: CrashReporter? = null
     private var breadcrumbManager: BreadcrumbManager? = null
@@ -111,7 +108,7 @@ internal class CrashReportingService(
             TelemetryEvent(
                 type = "event",
                 eventName = "app.crash",
-                timestamp = dateFormat.format(Date()),
+                timestamp = TelemetryTime.now(),
                 attributes = it
             )
         }
@@ -121,7 +118,7 @@ internal class CrashReportingService(
             
             val batch = TelemetryBatch(
                 batchSize = 1,
-                timestamp = dateFormat.format(Date()),
+                timestamp = TelemetryTime.now(),
                 events = listOf(it)
             )
             persistBatchSync(batch)

--- a/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/services/EventTrackingService.kt
+++ b/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/services/EventTrackingService.kt
@@ -9,9 +9,7 @@ import com.androidtel.telemetry_library.core.models.EventAttributes
 import com.androidtel.telemetry_library.core.models.TelemetryEvent
 import com.androidtel.telemetry_library.core.models.UserInfo
 import com.androidtel.telemetry_library.core.models.SessionInfo
-import java.text.SimpleDateFormat
-import java.util.Date
-import java.util.Locale
+import com.androidtel.telemetry_library.core.TelemetryTime
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -31,7 +29,6 @@ internal class EventTrackingService(
     private val config: TelemetryConfig
 ) {
     private val eventQueue = ConcurrentLinkedQueue<TelemetryEvent>()
-    private val dateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US)
     private val eventCount = AtomicInteger(0)
     private val metricCount = AtomicInteger(0)
     
@@ -60,7 +57,7 @@ internal class EventTrackingService(
             TelemetryEvent(
                 type = "event",
                 eventName = eventName,
-                timestamp = dateFormat.format(Date()),
+                timestamp = TelemetryTime.now(),
                 attributes = it
             )
         }
@@ -86,7 +83,7 @@ internal class EventTrackingService(
                 type = "metric",
                 metricName = metricName,
                 value = value,
-                timestamp = dateFormat.format(Date()),
+                timestamp = TelemetryTime.now(),
                 attributes = it
             )
         }
@@ -115,7 +112,7 @@ internal class EventTrackingService(
             "http.method" to method,
             "http.status_code" to statusCode,
             "http.duration_ms" to durationMs,
-            "http.timestamp" to dateFormat.format(Date()),
+            "http.timestamp" to TelemetryTime.now(),
             "http.success" to (statusCode < 400),
             "http.request_body_size" to requestBodySize,
             "http.response_body_size" to responseBodySize,
@@ -198,7 +195,7 @@ internal class EventTrackingService(
     /**
      * Get current timestamp in ISO format
      */
-    fun getCurrentTimestamp(): String = dateFormat.format(Date())
+    fun getCurrentTimestamp(): String = TelemetryTime.now()
     
     companion object {
         private const val TAG = "EventTrackingService"

--- a/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/services/SessionService.kt
+++ b/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/services/SessionService.kt
@@ -6,9 +6,7 @@ import com.androidtel.telemetry_library.core.TelemetryConfig
 import com.androidtel.telemetry_library.core.ids.IdGenerator
 import com.androidtel.telemetry_library.core.models.SessionInfo
 import com.androidtel.telemetry_library.core.session.SessionManager
-import java.text.SimpleDateFormat
-import java.util.Date
-import java.util.Locale
+import com.androidtel.telemetry_library.core.TelemetryTime
 
 /**
  * SessionService - Handles session lifecycle and tracking
@@ -25,7 +23,6 @@ internal class SessionService(
     private val config: TelemetryConfig,
     private val idGenerator: IdGenerator
 ) {
-    private val dateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US)
     private val prefs = context.getSharedPreferences("telemetry_prefs", Context.MODE_PRIVATE)
     
     private lateinit var sessionId: String
@@ -97,7 +94,7 @@ internal class SessionService(
         
         return SessionInfo(
             sessionId = getCurrentSessionId(),
-            startTime = dateFormat.format(Date(sessionStartTime)),
+            startTime = TelemetryTime.isoOf(sessionStartTime),
             durationMs = duration,
             eventCount = eventCount,
             metricCount = metricCount,

--- a/telemetry_library/src/test/java/com/androidtel/telemetry_library/core/TelemetryTimeTest.kt
+++ b/telemetry_library/src/test/java/com/androidtel/telemetry_library/core/TelemetryTimeTest.kt
@@ -1,0 +1,61 @@
+package com.androidtel.telemetry_library.core
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.util.TimeZone
+
+/**
+ * Seam 2 — verifies [TelemetryTime] produces true-UTC ISO-8601 millisecond strings regardless
+ * of the JVM/device default timezone. Guards against the "fake UTC" bug where a `SimpleDateFormat`
+ * appends a literal `Z` but formats in the device's local timezone.
+ */
+class TelemetryTimeTest {
+
+    private lateinit var originalTz: TimeZone
+
+    @Before
+    fun setUp() {
+        originalTz = TimeZone.getDefault()
+    }
+
+    @After
+    fun tearDown() {
+        TimeZone.setDefault(originalTz)
+    }
+
+    @Test
+    fun `isoOf epoch zero is the UTC epoch string`() {
+        assertEquals("1970-01-01T00:00:00.000Z", TelemetryTime.isoOf(0L))
+    }
+
+    @Test
+    fun `isoOf formats a known epoch as true UTC millisecond string`() {
+        // 2026-07-16T09:41:00.123Z
+        val epochMs = 1_784_194_860_123L
+        assertEquals("2026-07-16T09:41:00.123Z", TelemetryTime.isoOf(epochMs))
+    }
+
+    @Test
+    fun `isoOf ignores a non-UTC default timezone`() {
+        TimeZone.setDefault(TimeZone.getTimeZone("America/New_York")) // UTC-4/5
+        assertEquals("1970-01-01T00:00:00.000Z", TelemetryTime.isoOf(0L))
+
+        TimeZone.setDefault(TimeZone.getTimeZone("Africa/Nairobi")) // UTC+3
+        assertEquals("2026-07-16T09:41:00.123Z", TelemetryTime.isoOf(1_784_194_860_123L))
+    }
+
+    @Test
+    fun `now produces a fixed-width UTC ISO-8601 millisecond string`() {
+        val value = TelemetryTime.now()
+        // e.g. 2026-07-16T09:41:00.123Z — exactly 24 chars, ends in millis + Z
+        assertEquals(24, value.length)
+        assertTrue("expected trailing Z, got $value", value.endsWith("Z"))
+        assertTrue(
+            "unexpected shape: $value",
+            value.matches(Regex("""\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z"""))
+        )
+    }
+}


### PR DESCRIPTION
Closes #49 · PRD #45 (Wave 0) · spec `docs/specs/timestamp-correctness.md`

## What & why
Fixes two timestamp defects:
1. **Fake UTC** — every `SimpleDateFormat` appended a literal `Z` but formatted in the device's *default* timezone (no `setTimeZone(UTC)` anywhere), so every non-UTC device was silently skewed by its offset.
2. **`Instant.now()` API-26 landmine** — the SDK's `minSdk` is 24 with core-library desugaring disabled, so `java.time.Instant.now()` `NoSuchMethodError`s on Android 7.0/7.1 — including on the crash path (a crash reporter that crashes while reporting).

## Changes
- New `core/TelemetryTime.kt`: one `ThreadLocal<SimpleDateFormat>` pinned to UTC, pattern `yyyy-MM-dd'T'HH:mm:ss.SSS'Z'` (ms precision, D6). Stdlib only — no `java.time`, no desugaring, no new dependency. `now()` / `isoOf(epochMs)`.
- Deleted all **live** ad-hoc `SimpleDateFormat` formatters (`TelemetryManager` public `dateFormat` + the 4 service fields + inline `TrackComposeScreen`) → route through `TelemetryTime`.
- Removed all **live** `Instant.now()` (`NavigationStackTracker`, `Breadcrumb`, live Compose tracker `EdgeTelemetryCompose`) → `TelemetryTime.now()`.
- Converted point-in-time attribute literals to ISO strings (`initialization_timestamp`; `memory.timestamp` in `MemoryTracker` + `TelemetryMemoryUsage`), fixing the `memory.timestamp` Long-vs-String double shape.
- `*_ms` duration attributes left numeric.

## Scope notes
- `Instant.now()` remains only in already-dead files (`JsonEventTracker`, `FlutterCompatiblePayload`, `EdgeTelemetryInterceptor`) deleted by #55/#56/#57 — per spec, not re-touched here.
- Epoch-ms sites left per spec: the retired `screen_view` timestamp at the lifecycle observer (#35) and the internal `last_active_timestamp` persistence Long.

## Acceptance
- [x] `TelemetryTime.now()` produces true-UTC ISO-8601 ms-precision under a non-UTC default timezone (unit test — Seam 2)
- [x] All live formatters deleted; single UTC helper used everywhere
- [x] Zero live `Instant.now()` calls remain
- [x] `*_ms` duration attributes remain numeric

## Testing
`TelemetryTimeTest` (Seam 2) asserts true-UTC ISO output under `America/New_York` and `Africa/Nairobi` default timezones plus the fixed 24-char ms shape.

Verified: main Kotlin compiles under Gradle + JDK 17; `TelemetryTimeTest` compiled with kotlinc 2.1.0 and run on JUnit → **OK (4 tests)**. The AAPT2 resource step could not execute in the ARM64 sandbox (Google ships no ARM64 aapt2; Rosetta lacks the x86 loader) — it runs in the real x86 CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)