### PR TITLE
feat(#48): unified telemetry_batch envelope + sdk.* common attrs

### DIFF
--- a/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/TelemetryHttpClient.kt
+++ b/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/TelemetryHttpClient.kt
@@ -7,7 +7,6 @@ import com.androidtel.telemetry_library.core.models.EventAttributes
 import com.androidtel.telemetry_library.core.models.TelemetryBatch
 import com.androidtel.telemetry_library.core.models.TelemetryDataOut
 import com.androidtel.telemetry_library.core.models.TelemetryEventOut
-import com.androidtel.telemetry_library.core.models.TelemetryPayload
 import com.google.gson.Gson
 import kotlinx.coroutines.delay
 import okhttp3.MediaType.Companion.toMediaType
@@ -121,31 +120,17 @@ class TelemetryHttpClient(
             .addHeader("Content-Type", "application/json")
             .addHeader("User-Agent", "EdgeTelemetryAndroid/${BuildConfig.SDK_VERSION}")
             .addHeader("X-API-Key", apiKey)
-            .addHeader("X-SDK-Version", BuildConfig.SDK_VERSION)
-            .addHeader("X-SDK-Platform", "android")
             .build()
         return okHttpClient.newCall(request).execute()
     }
 
 
     // --- Extension: Convert Batch -> Outgoing JSON ---
+    // Serializes the single unified `telemetry_batch` envelope (issue #48). device.id lives per
+    // event in `attributes` (guarded in flattenAttributes); no top-level device_id/location.
     fun TelemetryBatch.toJson(): String {
-        // Extract device_id from the first event's attributes
-        val deviceId = this.events.firstOrNull()?.attributes?.device?.deviceId
-        
-        // CRITICAL: device_id must NEVER be null or empty
-        // This should never happen due to validation in TelemetryManager.sendBatch()
-        if (deviceId.isNullOrBlank()) {
-            throw IllegalStateException(
-                "CRITICAL ERROR: device_id is null or empty in telemetry batch. " +
-                "This indicates IDs were not properly validated before sending."
-            )
-        }
-        
-        val safeDeviceId = deviceId
-        
         val out = TelemetryDataOut(
-            type = "batch",
+            type = "telemetry_batch",
             events = this.events.map { event ->
                 TelemetryEventOut(
                     type = event.type,
@@ -157,18 +142,18 @@ class TelemetryHttpClient(
                 )
             },
             batch_size = this.batchSize,
-            timestamp = this.timestamp,
-            device_id = safeDeviceId,
-            location = this.location
+            timestamp = this.timestamp
         )
-        
-        // Send TelemetryDataOut directly (no wrapper) to match backend's expected format
         return Gson().toJson(out)
     }
 
     // ---- Helper: Flatten attributes into map ----
     private fun flattenAttributes(attrs: EventAttributes): Map<String, Any?> {
         val flat = mutableMapOf<String, Any?>()
+
+        // SDK identity — required common attrs on every event (issue #48). Replaces the X-SDK-* headers.
+        flat["sdk.version"] = BuildConfig.SDK_VERSION
+        flat["sdk.platform"] = "android"
 
         // App
         flat["app.name"] = attrs.app.appName

--- a/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/models/TelemetryBatch.kt
+++ b/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/models/TelemetryBatch.kt
@@ -12,13 +12,14 @@ data class TelemetryPayload(
     fun toJson(): String = Gson().toJson(this)
 }
 
+// Unified wire envelope (issue #48). Top-level is exactly {type, timestamp, batch_size, events}.
+// device_id/location/tenant_id/data-wrapper are gone: device.id is a per-event attr, geo is
+// collector-derived, tenant is identified server-side by X-API-Key.
 data class TelemetryDataOut(
-    val type: String = "batch",
+    val type: String = "telemetry_batch",
     val events: List<TelemetryEventOut>,
     val batch_size: Int,
-    val timestamp: String,
-    val device_id: String,
-    val location: String? = null
+    val timestamp: String
 )
 
 // ---- Flattened Event ----

--- a/telemetry_library/src/test/java/com/androidtel/telemetry_library/LocationIntegrationTest.kt
+++ b/telemetry_library/src/test/java/com/androidtel/telemetry_library/LocationIntegrationTest.kt
@@ -92,43 +92,6 @@ class LocationIntegrationTest {
     }
 
     @Test
-    fun `location is included in telemetry batch payload`() = runBlocking {
-        val jsonResponse = """
-            {
-                "ip": "105.163.0.47",
-                "city": "Mombasa",
-                "country": "Kenya"
-            }
-        """.trimIndent()
-        
-        mockWebServer.enqueue(MockResponse()
-            .setResponseCode(200)
-            .setBody(jsonResponse))
-
-        locationProvider = IpLocationProvider(
-            httpClient = httpClient,
-            apiEndpoint = mockWebServer.url("/json").toString(),
-            cacheDuration = 3600000,
-            fallbackToIp = true
-        )
-
-        val location = locationProvider.getLocation()
-        val batch = createTestTelemetryBatch()
-        
-        val telemetryDataOut = TelemetryDataOut(
-            type = "batch",
-            device_id = "test_device_123",
-            events = batch.events.map { convertToTelemetryEventOut(it) },
-            batch_size = batch.batchSize,
-            timestamp = batch.timestamp.toString(),
-            location = location
-        )
-        
-        assertNotNull(telemetryDataOut.location)
-        assertEquals("Mombasa/Kenya", telemetryDataOut.location)
-    }
-
-    @Test
     fun `IP address is included in payload when API returns IP fallback`() = runBlocking {
         val jsonResponse = """
             {
@@ -361,80 +324,5 @@ class LocationIntegrationTest {
         }
     }
 
-    private fun createTestTelemetryBatch(): TelemetryBatch {
-        val appInfo = AppInfo(
-            appName = "TestApp",
-            appVersion = "1.0.0",
-            appBuildNumber = "100",
-            appPackageName = "com.test.app"
-        )
 
-        val deviceInfo = DeviceInfo(
-            deviceId = "test_device_123",
-            platform = "Android",
-            platformVersion = "13",
-            model = "TestModel",
-            manufacturer = "TestManufacturer",
-            brand = "TestBrand",
-            androidSdk = "33",
-            androidRelease = "13",
-            fingerprint = "test_fingerprint",
-            hardware = "test_hardware",
-            product = "test_product"
-        )
-
-        val userInfo = UserInfo(
-            userId = "test_user_123",
-            name = null,
-            email = null,
-            phone = null
-        )
-
-        val sessionInfo = SessionInfo(
-            sessionId = "test_session_123",
-            startTime = System.currentTimeMillis().toString(),
-            durationMs = 1000L,
-            eventCount = 1,
-            metricCount = 0,
-            screenCount = 1,
-            visitedScreens = "TestScreen",
-            isFirstSession = false,
-            totalSessions = 5,
-            networkType = "WiFi"
-        )
-
-        val attributes = EventAttributes(
-            app = appInfo,
-            device = deviceInfo,
-            user = userInfo,
-            session = sessionInfo,
-            customAttributes = emptyMap()
-        )
-
-        val event = TelemetryEvent(
-            type = "event",
-            eventName = "test.event",
-            metricName = null,
-            value = null,
-            timestamp = System.currentTimeMillis().toString(),
-            attributes = attributes
-        )
-
-        return TelemetryBatch(
-            batchSize = 1,
-            timestamp = System.currentTimeMillis().toString(),
-            events = listOf(event)
-        )
-    }
-
-    private fun convertToTelemetryEventOut(event: TelemetryEvent): TelemetryEventOut {
-        return TelemetryEventOut(
-            type = event.type,
-            eventName = event.eventName,
-            metricName = event.metricName,
-            value = event.value,
-            timestamp = event.timestamp.toString(),
-            attributes = emptyMap()
-        )
-    }
 }

--- a/telemetry_library/src/test/java/com/androidtel/telemetry_library/TelemetryHttpClientTest.kt
+++ b/telemetry_library/src/test/java/com/androidtel/telemetry_library/TelemetryHttpClientTest.kt
@@ -190,7 +190,7 @@ class TelemetryHttpClientTest {
         
         assertNotNull(body)
         assertTrue(body.isNotEmpty())
-        assertTrue(body.contains("\"device_id\""))
+        assertTrue(body.contains("\"type\":\"telemetry_batch\""))
         assertTrue(body.contains("\"timestamp\""))
     }
 

--- a/telemetry_library/src/test/java/com/androidtel/telemetry_library/UnifiedEnvelopeTest.kt
+++ b/telemetry_library/src/test/java/com/androidtel/telemetry_library/UnifiedEnvelopeTest.kt
@@ -1,0 +1,132 @@
+package com.androidtel.telemetry_library
+
+import com.androidtel.telemetry_library.core.TelemetryHttpClient
+import com.androidtel.telemetry_library.core.models.*
+import com.google.gson.JsonParser
+import kotlinx.coroutines.runBlocking
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import java.util.concurrent.TimeUnit
+
+/**
+ * Seam 1 (issue #48): assert the serialized `telemetry_batch` envelope on the wire.
+ *
+ * Drives the single `sendBatch` transport, captures the POST body via MockWebServer, and asserts
+ * the exact envelope shape + common `sdk.*` attrs + header set. This is the conformance contract
+ * for the unified wire envelope.
+ */
+class UnifiedEnvelopeTest {
+
+    private lateinit var mockWebServer: MockWebServer
+    private lateinit var httpClient: TelemetryHttpClient
+    private val testApiKey = "edge_test_api_key_12345"
+
+    @Before
+    fun setUp() {
+        mockWebServer = MockWebServer()
+        mockWebServer.start()
+        httpClient = TelemetryHttpClient(
+            telemetryUrl = mockWebServer.url("/telemetry").toString(),
+            apiKey = testApiKey,
+            debugMode = false
+        )
+    }
+
+    @After
+    fun tearDown() {
+        mockWebServer.shutdown()
+    }
+
+    private fun sendAndCaptureBody(batch: TelemetryBatch): String {
+        mockWebServer.enqueue(MockResponse().setResponseCode(200))
+        runBlocking { httpClient.sendBatch(batch) }
+        val request = mockWebServer.takeRequest(5, TimeUnit.SECONDS)!!
+        return request.body.readUtf8()
+    }
+
+    @Test
+    fun `envelope has exactly the unified top-level keys and no legacy fields`() {
+        val body = sendAndCaptureBody(createTestBatch())
+        val json = JsonParser.parseString(body).asJsonObject
+
+        assertEquals("telemetry_batch", json.get("type").asString)
+        assertEquals(setOf("type", "timestamp", "batch_size", "events"), json.keySet())
+
+        // Removed legacy fields (Path A + Path B leftovers).
+        assertFalse("device_id must not be top-level", json.has("device_id"))
+        assertFalse("location must not be top-level", json.has("location"))
+        assertFalse("data wrapper must be gone", json.has("data"))
+        assertFalse("tenant_id must be gone", json.has("tenant_id"))
+    }
+
+    @Test
+    fun `every event carries sdk and identity common attrs`() {
+        val body = sendAndCaptureBody(createTestBatch(events = 2))
+        val events = JsonParser.parseString(body).asJsonObject.getAsJsonArray("events")
+        assertTrue(events.size() > 0)
+
+        events.forEach { el ->
+            val attrs = el.asJsonObject.getAsJsonObject("attributes")
+            assertTrue("sdk.version present", attrs.has("sdk.version"))
+            assertFalse(attrs.get("sdk.version").asString.isBlank())
+            assertEquals("android", attrs.get("sdk.platform").asString)
+            assertTrue("device.id present", attrs.has("device.id"))
+            assertTrue("session.id present", attrs.has("session.id"))
+            assertTrue("user.id present", attrs.has("user.id"))
+        }
+    }
+
+    @Test
+    fun `session counters serialize as native JSON numbers`() {
+        val body = sendAndCaptureBody(createTestBatch())
+        val attrs = JsonParser.parseString(body).asJsonObject
+            .getAsJsonArray("events").get(0).asJsonObject
+            .getAsJsonObject("attributes")
+
+        val eventCount = attrs.get("session.event_count")
+        assertTrue("session.event_count must be a JSON number, not a string",
+            eventCount.isJsonPrimitive && eventCount.asJsonPrimitive.isNumber)
+    }
+
+    @Test
+    fun `X-SDK headers are removed and X-API-Key stays`() {
+        mockWebServer.enqueue(MockResponse().setResponseCode(200))
+        runBlocking { httpClient.sendBatch(createTestBatch()) }
+        val request = mockWebServer.takeRequest(5, TimeUnit.SECONDS)!!
+
+        assertEquals(testApiKey, request.getHeader("X-API-Key"))
+        assertNull(request.getHeader("X-SDK-Version"))
+        assertNull(request.getHeader("X-SDK-Platform"))
+    }
+
+    private fun createTestBatch(events: Int = 1): TelemetryBatch {
+        val attributes = EventAttributes(
+            app = AppInfo("TestApp", "1.0.0", "100", "com.test.app"),
+            device = DeviceInfo(
+                deviceId = "test_device_123", platform = "android", platformVersion = "13",
+                model = "TestModel", manufacturer = "TestManufacturer", brand = "TestBrand",
+                androidSdk = "33", androidRelease = "13", fingerprint = "fp",
+                hardware = "hw", product = "prod"
+            ),
+            user = UserInfo(userId = "test_user_123"),
+            session = SessionInfo(
+                sessionId = "test_session_123", startTime = "2026-07-20T00:00:00.000Z",
+                durationMs = 1000L, eventCount = 3, metricCount = 0, screenCount = 1,
+                visitedScreens = "TestScreen", isFirstSession = false, totalSessions = 5,
+                networkType = "wifi"
+            ),
+            customAttributes = emptyMap()
+        )
+        val evList = (1..events).map { i ->
+            TelemetryEvent(
+                type = "event", eventName = "test.event.$i", metricName = null, value = null,
+                timestamp = "2026-07-20T00:00:0$i.000Z", attributes = attributes
+            )
+        }
+        return TelemetryBatch(batchSize = evList.size, timestamp = "2026-07-20T00:00:00.000Z", events = evList)
+    }
+}

--- a/telemetry_library/src/test/java/com/androidtel/telemetry_library/core/TelemetryIdValidationTest.kt
+++ b/telemetry_library/src/test/java/com/androidtel/telemetry_library/core/TelemetryIdValidationTest.kt
@@ -153,8 +153,8 @@ class TelemetryIdValidationTest {
             fail("Should throw IllegalStateException when device ID is blank")
         } catch (e: IllegalStateException) {
             assertTrue(
-                "Exception message should mention device_id",
-                e.message?.contains("device_id") == true
+                "Exception message should mention device.id",
+                e.message?.contains("device.id") == true
             )
         }
     }


### PR DESCRIPTION
Closes #48.

Hard cutover to a single wire envelope on the batch / `sendBatch` transport. Scoped to the **envelope/transport rail only** — crash Path B retirement is deferred to #39 by explicit decision.

## What changed
- **`TelemetryDataOut`**: wire `type` `"batch"` → `"telemetry_batch"`; drop top-level `device_id`/`location`. Top-level is now exactly `{type, timestamp, batch_size, events}`.
- **`flattenAttributes`**: add required common attrs `sdk.version` (`BuildConfig.SDK_VERSION`) + `sdk.platform` (`"android"`) to every event — replaces the `X-SDK-*` headers.
- **`makeHttpRequest`**: drop `X-SDK-Version`/`X-SDK-Platform`; keep `X-API-Key`.
- Relocate the never-blank `device.id` guard into `flattenAttributes` (the only place `device.id` is emitted now that it's no longer top-level).

## Acceptance criteria
- [x] Every event serializes into one `telemetry_batch` envelope; no second envelope shape on the batch rail
- [x] `sdk.version` + `sdk.platform` present as common attrs on every batch
- [x] `X-SDK-*` headers removed (batch transport)
- [x] Top-level `device_id`/`location`/`tenant_id` dropped
- [x] Single `sendBatch` transport; Seam 1 test asserts serialized batch shape

## Tests
`UnifiedEnvelopeTest` (Seam 1) drives `sendBatch` through MockWebServer and asserts the exact envelope keyset, absence of `device_id`/`location`/`data`/`tenant_id`, per-event `sdk.*`/`device.id`/`session.id`/`user.id`, native-typed session counters, and the header set. Full unit suite (515 tests) + `lintDebug` green.

## Deferred (not this ticket)
- Crash Path B retirement (durable rail, `CrashBatchEnvelope`/`getCrashAttributes` deletion, `CrashRetryManager` rewiring) → #39
- Dead `TelemetryBatch.location` plumbing + orphaned `TelemetryPayload` wrapper → #37 (dead-code-removal)

## Backend note
Migration is a hard cutover (no dual-emit). The collector must accept `telemetry_batch`; legacy `type:"batch"` traffic from un-upgraded apps is disambiguated by `sdk.version`.