### PR TITLE
test(#41): salvage timestamp-source guard + fix two epoch-ms stragglers

### DIFF
--- a/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/TelemetryActivityLifecycleObserver.kt
+++ b/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/TelemetryActivityLifecycleObserver.kt
@@ -74,7 +74,7 @@ class TelemetryActivityLifecycleObserver(
                     "screen_name" to screenName,
                     "duration_ms" to durationMs,
                     "session_id" to telemetryManager.getSessionId(),
-                    "timestamp" to System.currentTimeMillis()
+                    "timestamp" to TelemetryTime.now()
                 )
             )
         }

--- a/telemetry_library/src/main/java/com/androidtel/telemetry_library/testing/EdgeTelemetryTester.kt
+++ b/telemetry_library/src/main/java/com/androidtel/telemetry_library/testing/EdgeTelemetryTester.kt
@@ -5,6 +5,7 @@ import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
 import android.util.Log
 import com.androidtel.telemetry_library.EdgeTelemetry
+import com.androidtel.telemetry_library.core.TelemetryTime
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -180,7 +181,7 @@ object EdgeTelemetryTester {
             // Test authenticated connectivity by sending a test event
             edgeTelemetry.recordEvent("api_key.validation_test", mapOf(
                 "test" to "api_key_validation",
-                "timestamp" to System.currentTimeMillis().toString()
+                "timestamp" to TelemetryTime.now()
             ))
             
             Log.i(TAG, "📡 Test event sent with API key authentication")

--- a/telemetry_library/src/test/java/com/androidtel/telemetry_library/core/TimestampSourceGuardTest.kt
+++ b/telemetry_library/src/test/java/com/androidtel/telemetry_library/core/TimestampSourceGuardTest.kt
@@ -1,0 +1,69 @@
+package com.androidtel.telemetry_library.core
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+/**
+ * #41 D-4 (2): static fence keeping the single-helper invariant. Fails if a
+ * timezone-less formatter, an API-26 `Instant.now()`, or a raw epoch-ms
+ * timestamp attribute sneaks back into `src/main`.
+ *
+ * ponytail: a grep-in-a-test, not a detekt rule — zero new tooling, rides the
+ * existing testDebugUnitTest gate (#31).
+ */
+class TimestampSourceGuardTest {
+
+    // Dead code still carrying Instant.now(); deleted by #37 (JsonEventTracker,
+    // FlutterCompatiblePayload) and #40 (EdgeTelemetryInterceptor). Drop these
+    // exclusions when those tickets land.
+    private val deadInstantFiles = setOf(
+        "JsonEventTracker.kt",
+        "FlutterCompatiblePayload.kt",
+        "EdgeTelemetryInterceptor.kt",
+    )
+
+    private val srcMain: File =
+        listOf(File("src/main"), File("telemetry_library/src/main"))
+            .first { it.isDirectory }
+
+    private fun kotlinSources(): List<File> =
+        srcMain.walkTopDown().filter { it.isFile && it.extension == "kt" }.toList()
+
+    @Test
+    fun `SimpleDateFormat lives only in TelemetryTime`() {
+        val offenders = kotlinSources()
+            .filter { it.name != "TelemetryTime.kt" }
+            .filter { it.readText().contains("SimpleDateFormat(") }
+            .map { it.name }
+        assertTrue(
+            "SimpleDateFormat must go through TelemetryTime; found in: $offenders",
+            offenders.isEmpty()
+        )
+    }
+
+    @Test
+    fun `no live Instant now (API-26 landmine)`() {
+        val offenders = kotlinSources()
+            .filter { it.name != "TelemetryTime.kt" } // names it in a doc comment
+            .filter { it.name !in deadInstantFiles }
+            .filter { it.readText().contains("Instant.now(") }
+            .map { it.name }
+        assertTrue(
+            "Instant.now() crashes on minSdk 24/25; use TelemetryTime. Found in: $offenders",
+            offenders.isEmpty()
+        )
+    }
+
+    @Test
+    fun `no raw epoch-ms timestamp attributes`() {
+        val pattern = Regex(""""[^"]*timestamp[^"]*"\s+to\s+System\.currentTimeMillis\(""")
+        val offenders = kotlinSources()
+            .filter { pattern.containsMatchIn(it.readText()) }
+            .map { it.name }
+        assertTrue(
+            "Timestamp attributes must be ISO via TelemetryTime, not epoch-ms. Found in: $offenders",
+            offenders.isEmpty()
+        )
+    }
+}


### PR DESCRIPTION
Salvages the one useful artifact from the abandoned local `feat/41` branch before deleting it: a static grep-in-a-test fence enforcing the single-timestamp-helper invariant established by #49.

## What the guard enforces
Rides the existing `testDebugUnitTest` gate (zero new tooling) — fails if any `src/main` Kotlin file reintroduces:
- `SimpleDateFormat(` outside `TelemetryTime`
- `Instant.now(` (an API-26 landmine on minSdk 24/25) — excluding three dead files that still carry it, dropped by #37/#40
- a raw epoch-ms `"…timestamp…"` attribute (`… to System.currentTimeMillis()`)

## Stragglers it caught
The third rule flagged two attributes the #49 ISO-8601 migration missed. Both now route through `TelemetryTime.now()`:
- `TelemetryActivityLifecycleObserver` — `screen_view` `"timestamp"` (**was `Long` epoch-ms → now ISO-8601 string**; wire-format change for that attribute)
- `EdgeTelemetryTester` — `api_key.validation_test` `"timestamp"` (test util)

## Verification
`TimestampSourceGuardTest` green against current master.

Also deleted the stranded local `feat/41-timestamp-correctness` branch (its content was superseded by #49; this test was the only part not already on master).