### PR TITLE
feat(#51): bound buffers & eviction — offline 200 / queue 500 drop-oldest

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ edge_telemetry_android/
 │           ├── TelemetryConfig.kt        # Configuration data class
 │           ├── TelemetryHttpClient.kt    # HTTP transport layer
 │           ├── TelemetryInterceptor.kt   # OkHttp interceptor for network tracking
-│           ├── OfflineBatchStorage.kt    # Room-based offline persistence
+│           ├── OfflineBatchStorage.kt    # SharedPreferences offline persistence (200-envelope cap)
 │           ├── ScreenTimingTracker.kt    # Screen duration measurement
 │           ├── MemoryTracker.kt          # Memory pressure monitoring
 │           ├── DeviceCapabilities.kt     # Runtime capability detection
@@ -190,7 +190,6 @@ tm.setLastUserAction("submit_payment")
 
 - **OkHttp3** 4.12.0 — HTTP transport + network interceptor
 - **Gson** 2.10.1 — JSON serialization
-- **AndroidX Room** 2.6.1 — offline batch persistence
 - **AndroidX Work** 2.9.0 — background retry scheduling
 - **AndroidX Lifecycle** 2.9.2 — process/activity lifecycle observation
 - **AndroidX Navigation** 2.9.3 — Compose navigation tracking

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,8 +37,6 @@ androidx-lifecycle-process = { group = "androidx.lifecycle", name = "lifecycle-p
 androidx-navigation-runtime-android = { group = "androidx.navigation", name = "navigation-runtime-android", version.ref = "navigationRuntimeAndroid" }
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationRuntimeAndroid" }
 androidx-work-runtime = { group = "androidx.work", name = "work-runtime-ktx", version = "2.9.0" }
-androidx-room-runtime = { group = "androidx.room", name = "room-runtime", version = "2.6.1" }
-androidx-room-ktx = { group = "androidx.room", name = "room-ktx", version = "2.6.1" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/telemetry_library/build.gradle.kts
+++ b/telemetry_library/build.gradle.kts
@@ -116,10 +116,9 @@ dependencies {
     
     // WorkManager for retry scheduling
     api(libs.androidx.work.runtime)
-    
-    // Room for offline storage
-    api(libs.androidx.room.runtime)
-    api(libs.androidx.room.ktx)
+
+    // Offline storage is SharedPreferences-based (OfflineBatchStorage) — no Room. The Room runtime
+    // deps were dead weight (declared without a compiler/ksp plugin) and have been dropped.
 
     // Desugaring - removed since we no longer use Java 8 time APIs
     // implementation("com.android.tools:desugar_jdk_libs:2.0.4")

--- a/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/CountedEventQueue.kt
+++ b/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/CountedEventQueue.kt
@@ -1,0 +1,52 @@
+package com.androidtel.telemetry_library.core
+
+import com.androidtel.telemetry_library.core.models.TelemetryEvent
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Bounded, drop-oldest in-memory event queue with an O(1) size.
+ *
+ * `ConcurrentLinkedQueue.size` is O(n) — it walks the list to count — so a per-enqueue cap check on
+ * it would make enqueue O(n²). The count is tracked in an [AtomicInteger] instead.
+ *
+ * Cap is [MAX_EVENTS], drop-oldest: a burst or send-stall trims the front (oldest events) rather
+ * than growing without bound. Recent events are closer to the current user state / a crash, so the
+ * oldest are the cheapest to lose.
+ *
+ * ponytail: the cap check and the offer are not one atomic step, so under heavy concurrent enqueue
+ * the count can briefly exceed MAX_EVENTS before the next drop-oldest trims it back — fine for a
+ * soft memory cap. Add a lock only if a hard ceiling is ever required.
+ */
+class CountedEventQueue {
+    private val queue = ConcurrentLinkedQueue<TelemetryEvent>()
+    private val count = AtomicInteger(0)
+
+    /** O(1) authoritative count. */
+    val size: Int get() = count.get()
+
+    fun isEmpty(): Boolean = count.get() == 0
+    fun isNotEmpty(): Boolean = !isEmpty()
+
+    /** Append, evicting the oldest first if already at capacity. */
+    fun enqueue(event: TelemetryEvent) {
+        if (count.get() >= MAX_EVENTS && queue.poll() != null) count.decrementAndGet()
+        queue.offer(event)
+        count.incrementAndGet()
+    }
+
+    /** Remove and return the oldest event, or null if empty. */
+    fun poll(): TelemetryEvent? {
+        val event = queue.poll()
+        if (event != null) count.decrementAndGet()
+        return event
+    }
+
+    /** Peek the oldest event without removing it. */
+    fun peek(): TelemetryEvent? = queue.peek()
+
+    companion object {
+        // 10× the default batchSize (50): absorbs a send-stall or burst, well above one batch.
+        const val MAX_EVENTS = 500
+    }
+}

--- a/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/OfflineBatchStorage.kt
+++ b/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/OfflineBatchStorage.kt
@@ -6,47 +6,64 @@ import com.androidtel.telemetry_library.core.models.TelemetryBatch
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 
-// A simple implementation of offline storage using SharedPreferences.
-// A more robust solution would use a local database like Room.
+// Offline storage using SharedPreferences: a 200-envelope, drop-oldest bounded buffer (D9).
+//
+// Room is deliberately NOT used — it is declared runtime+ktx only (no compiler, no ksp), i.e. dead
+// weight, and this store fills only while offline (low write frequency). Upgrade path if offline
+// depth becomes real: wire Room properly (@Entity per envelope, DELETE ... ORDER BY seq LIMIT).
 class OfflineBatchStorage(context: Context) {
     private val prefs = context.getSharedPreferences("telemetry_batches", Context.MODE_PRIVATE)
     private val gson = Gson()
     private val batchListType = object : TypeToken<List<TelemetryBatch>>() {}.type
 
+    // Serializes all mutations. storeBatch/removeBatch/clear do read-modify-write of the whole blob;
+    // without this, two concurrent writes race and last-write-wins silently drops a batch.
+    private val mutex = Mutex()
+
     companion object {
         private const val PREFS_KEY = "stored_batches"
+        // Hub decision D9 (issue #33 spec): the durable offline buffer is 200 envelopes, drop-oldest.
+        const val MAX_ENVELOPES = 200
     }
 
-    // Stores a single batch to the persistent storage.
+    // Stores a single batch, capping at MAX_ENVELOPES (drop-oldest).
     suspend fun storeBatch(batch: TelemetryBatch) = withContext(Dispatchers.IO) {
-        val batches = getStoredBatches().toMutableList()
-        batches.add(batch)
-        val json = gson.toJson(batches)
-        prefs.edit().putString(PREFS_KEY, json).apply()
+        mutex.withLock {
+            val batches = readBatches().toMutableList()
+            batches.add(batch)
+            // The list is append-ordered, so the front is oldest: drop from the front past the cap.
+            val capped = if (batches.size > MAX_ENVELOPES)
+                batches.subList(batches.size - MAX_ENVELOPES, batches.size) else batches
+            prefs.edit().putString(PREFS_KEY, gson.toJson(capped)).apply()
+        }
     }
 
-    // Retrieves all stored batches from the persistent storage.
+    // Retrieves all stored batches, oldest-first (append order). Intentionally lock-free: only
+    // mutations need serializing, so a concurrent reader may observe the pre-write blob — fine for
+    // a soft offline buffer (it just replays those envelopes on the next tick).
     suspend fun getStoredBatches(): List<TelemetryBatch> = withContext(Dispatchers.IO) {
-        val json = prefs.getString(PREFS_KEY, null)
-        return@withContext if (json != null) {
-            gson.fromJson(json, batchListType) ?: emptyList()
-        } else {
-            emptyList()
-        }
+        readBatches()
     }
 
     // Removes a specific batch by its ID.
     suspend fun removeBatch(batchId: String) = withContext(Dispatchers.IO) {
-        val batches = getStoredBatches().toMutableList()
-        val updatedBatches = batches.filter { it.id != batchId }
-        val json = gson.toJson(updatedBatches)
-        prefs.edit().putString(PREFS_KEY, json).apply()
+        mutex.withLock {
+            val remaining = readBatches().filter { it.id != batchId }
+            prefs.edit().putString(PREFS_KEY, gson.toJson(remaining)).apply()
+        }
     }
 
     // Clears all stored batches.
     suspend fun clearAllBatches() = withContext(Dispatchers.IO) {
-        prefs.edit().remove(PREFS_KEY).apply()
+        mutex.withLock { prefs.edit().remove(PREFS_KEY).apply() }
+    }
+
+    private fun readBatches(): List<TelemetryBatch> {
+        val json = prefs.getString(PREFS_KEY, null) ?: return emptyList()
+        return gson.fromJson(json, batchListType) ?: emptyList()
     }
 }

--- a/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/TelemetryManager.kt
+++ b/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/TelemetryManager.kt
@@ -291,7 +291,11 @@ class TelemetryManager private constructor(
             // Timed flush force-sends partial batches so a low-activity session doesn't hold
             // telemetry indefinitely. Empty queue no-ops inside sendBatch (no heartbeat traffic).
             batchProcessingService.initialize(onFlush = {
-                scope.launch { sendBatch(forceSend = true) }
+                scope.launch {
+                    sendBatch(forceSend = true)
+                    // Replay offline-stored envelopes, throttled per tick (offline-store → network).
+                    sendStoredBatches()
+                }
             })
             Log.d("TelemetryManager", "Step 8: BatchProcessingService initialized")
             
@@ -402,12 +406,9 @@ class TelemetryManager private constructor(
 
         Log.i("TelemetryManager", "App moved to foreground")
 
-        // 1. Restore offline buffer back into in-memory event queue
-        scope.launch {
-            batchProcessingService.restoreOfflineBatches(eventTrackingService.getEventQueue())
-        }
-
-        // 2. Check session timeout and start new session if needed
+        // 1. Check session timeout and start new session if needed
+        // (Offline-stored envelopes replay via the flush tick — see sendStoredBatches — not by
+        //  restoring them into the in-memory queue, which would re-batch and evict live events.)
         if (sessionService.hasSessionTimedOut()) {
             val lastActive = sessionService.getLastActiveTimestamp()
             if (lastActive > 0) {
@@ -425,10 +426,10 @@ class TelemetryManager private constructor(
             Log.i("TelemetryManager", "Resuming existing session (elapsed: ${elapsed}ms)")
         }
         
-        // 3. Resume the flush timer
+        // 2. Resume the flush timer
         batchProcessingService.resumeFlushTimer()
 
-        // 4. Sample memory on each foreground transition — bounded by user-engagement cadence
+        // 3. Sample memory on each foreground transition — bounded by user-engagement cadence
         sampleMemoryUsage()
     }
 
@@ -530,7 +531,7 @@ class TelemetryManager private constructor(
         crashReportingService.recordCrash(
             throwable = throwable,
             buildAttributesFn = { attrs -> buildAttributes(attrs) },
-            onEventCreated = { event -> eventTrackingService.getEventQueue().add(event) }
+            onEventCreated = { event -> eventTrackingService.getEventQueue().enqueue(event) }
         )
     }
 

--- a/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/services/BatchProcessingService.kt
+++ b/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/services/BatchProcessingService.kt
@@ -1,6 +1,7 @@
 package com.androidtel.telemetry_library.core.services
 
 import android.util.Log
+import com.androidtel.telemetry_library.core.CountedEventQueue
 import com.androidtel.telemetry_library.core.OfflineBatchStorage
 import com.androidtel.telemetry_library.core.TelemetryConfig
 import com.androidtel.telemetry_library.core.TelemetryHttpClient
@@ -8,10 +9,8 @@ import com.androidtel.telemetry_library.core.models.TelemetryBatch
 import com.androidtel.telemetry_library.core.models.TelemetryEvent
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import com.androidtel.telemetry_library.core.TelemetryTime
-import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
@@ -71,7 +70,7 @@ internal class BatchProcessingService(
      * required.
      */
     suspend fun sendBatch(
-        eventQueue: ConcurrentLinkedQueue<TelemetryEvent>,
+        eventQueue: CountedEventQueue,
         forceSend: Boolean = false,
         flushOffline: Boolean = true,
         location: String? = null
@@ -80,11 +79,11 @@ internal class BatchProcessingService(
             Log.w(TAG, "Skipping batch send - IDs not properly initialized. Events remain queued (${eventQueue.size} events).")
             return
         }
-        
+
         if (!forceSend && eventQueue.size < config.batchSize) {
             return
         }
-        
+
         val eventsToSend = mutableListOf<TelemetryEvent>()
         repeat(eventQueue.size) {
             val ev = eventQueue.poll()
@@ -114,30 +113,37 @@ internal class BatchProcessingService(
     }
     
     /**
-     * Send stored batches from offline storage.
+     * Replay stored offline batches, oldest-first.
+     *
+     * Throttled to at most [REPLAY_BATCH_LIMIT] envelopes per call and stops on the first failure:
+     * a device offline long enough to fill the store must not fire the whole store back-to-back on
+     * reconnect, and a failure means the collector isn't ready for more. The flush timer paces the
+     * rest across subsequent ticks. Replay goes offline-store → network directly (never back through
+     * the in-memory queue).
      */
     suspend fun sendStoredBatches() {
         Log.i(TAG, "Checking for stored batches to send.")
         val storedBatches = offlineStorage.getStoredBatches()
-        if (storedBatches.isNotEmpty()) {
-            Log.i(TAG, "Found ${storedBatches.size} stored batches. Attempting to send.")
-            storedBatches.forEach { batch ->
-                val result = httpClient.sendBatch(batch)
-                if (result.isSuccess) {
-                    Log.i(TAG, "Successfully re-sent stored batch.")
-                    offlineStorage.removeBatch(batch.id)
-                } else {
-                    Log.e(TAG, "Failed to re-send stored batch. Will try again later.")
-                }
+        if (storedBatches.isEmpty()) return
+
+        Log.i(TAG, "Found ${storedBatches.size} stored batches. Replaying up to $REPLAY_BATCH_LIMIT.")
+        for (batch in storedBatches.take(REPLAY_BATCH_LIMIT)) {
+            val result = httpClient.sendBatch(batch)
+            if (result.isSuccess) {
+                Log.i(TAG, "Successfully re-sent stored batch.")
+                offlineStorage.removeBatch(batch.id)
+            } else {
+                Log.e(TAG, "Stored batch send failed; pausing replay until next flush tick.")
+                return
             }
         }
     }
-    
+
     /**
      * Trigger batch send asynchronously.
      */
     fun triggerBatchSend(
-        eventQueue: ConcurrentLinkedQueue<TelemetryEvent>,
+        eventQueue: CountedEventQueue,
         location: String? = null
     ): Job {
         batchSendJob = scope.launch {
@@ -145,31 +151,11 @@ internal class BatchProcessingService(
         }
         return batchSendJob!!
     }
-    
-    /**
-     * Restore offline batches to event queue
-     */
-    suspend fun restoreOfflineBatches(eventQueue: ConcurrentLinkedQueue<TelemetryEvent>) {
-        try {
-            val batches = offlineStorage.getStoredBatches()
-            batches.forEach { batch ->
-                batch.events.forEach { event ->
-                    eventQueue.offer(event)
-                }
-                offlineStorage.removeBatch(batch.id)
-            }
-            if (batches.isNotEmpty()) {
-                Log.d(TAG, "Restored ${batches.size} batches from offline storage")
-            }
-        } catch (e: Exception) {
-            Log.e(TAG, "Error restoring offline buffer", e)
-        }
-    }
-    
+
     /**
      * Flush event queue to offline storage
      */
-    suspend fun flushToOfflineStorage(eventQueue: ConcurrentLinkedQueue<TelemetryEvent>) {
+    suspend fun flushToOfflineStorage(eventQueue: CountedEventQueue) {
         try {
             val eventsToStore = mutableListOf<TelemetryEvent>()
             while (eventQueue.isNotEmpty()) {
@@ -230,5 +216,7 @@ internal class BatchProcessingService(
     
     companion object {
         private const val TAG = "BatchProcessingService"
+        // Oldest envelopes drained per flush tick — caps reconnect burst; timer paces the rest.
+        const val REPLAY_BATCH_LIMIT = 10
     }
 }

--- a/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/services/EventTrackingService.kt
+++ b/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/services/EventTrackingService.kt
@@ -2,6 +2,7 @@ package com.androidtel.telemetry_library.core.services
 
 import android.content.Context
 import android.util.Log
+import com.androidtel.telemetry_library.core.CountedEventQueue
 import com.androidtel.telemetry_library.core.TelemetryConfig
 import com.androidtel.telemetry_library.core.models.AppInfo
 import com.androidtel.telemetry_library.core.models.DeviceInfo
@@ -10,7 +11,6 @@ import com.androidtel.telemetry_library.core.models.TelemetryEvent
 import com.androidtel.telemetry_library.core.models.UserInfo
 import com.androidtel.telemetry_library.core.models.SessionInfo
 import com.androidtel.telemetry_library.core.TelemetryTime
-import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.AtomicInteger
 
 /**
@@ -28,7 +28,7 @@ internal class EventTrackingService(
     private val context: Context,
     private val config: TelemetryConfig
 ) {
-    private val eventQueue = ConcurrentLinkedQueue<TelemetryEvent>()
+    private val eventQueue = CountedEventQueue()
     private val eventCount = AtomicInteger(0)
     private val metricCount = AtomicInteger(0)
     
@@ -62,7 +62,7 @@ internal class EventTrackingService(
             )
         }
         
-        event?.let { eventQueue.add(it) }
+        event?.let { eventQueue.enqueue(it) }
         return event
     }
     
@@ -88,7 +88,7 @@ internal class EventTrackingService(
             )
         }
         
-        event?.let { eventQueue.add(it) }
+        event?.let { eventQueue.enqueue(it) }
         return event
     }
     
@@ -144,7 +144,7 @@ internal class EventTrackingService(
     /**
      * Get event queue for batch processing
      */
-    fun getEventQueue(): ConcurrentLinkedQueue<TelemetryEvent> = eventQueue
+    fun getEventQueue(): CountedEventQueue = eventQueue
     
     /**
      * Get current event count

--- a/telemetry_library/src/test/java/com/androidtel/telemetry_library/core/CountedEventQueueTest.kt
+++ b/telemetry_library/src/test/java/com/androidtel/telemetry_library/core/CountedEventQueueTest.kt
@@ -1,0 +1,41 @@
+package com.androidtel.telemetry_library.core
+
+import com.androidtel.telemetry_library.core.models.TelemetryEvent
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Unit tests for CountedEventQueue — the 500-event, drop-oldest, O(1)-size in-memory queue.
+ */
+class CountedEventQueueTest {
+
+    private fun event(tag: String): TelemetryEvent =
+        mockk<TelemetryEvent>(relaxed = true).also { every { it.eventName } returns tag }
+
+    @Test
+    fun `caps at MAX_EVENTS dropping the oldest`() {
+        val queue = CountedEventQueue()
+        repeat(CountedEventQueue.MAX_EVENTS + 1) { queue.enqueue(event("e$it")) }
+
+        assertEquals(CountedEventQueue.MAX_EVENTS, queue.size)
+        // The very first event (e0) was evicted; the oldest survivor is e1.
+        assertEquals("e1", queue.peek()?.eventName)
+    }
+
+    @Test
+    fun `poll decrements size and drains in FIFO order`() {
+        val queue = CountedEventQueue()
+        queue.enqueue(event("a"))
+        queue.enqueue(event("b"))
+
+        assertEquals("a", queue.poll()?.eventName)
+        assertEquals(1, queue.size)
+        assertEquals("b", queue.poll()?.eventName)
+        assertEquals(0, queue.size)
+        assertNull(queue.poll())
+        assertEquals(0, queue.size)
+    }
+}

--- a/telemetry_library/src/test/java/com/androidtel/telemetry_library/core/OfflineBatchStorageTest.kt
+++ b/telemetry_library/src/test/java/com/androidtel/telemetry_library/core/OfflineBatchStorageTest.kt
@@ -1,0 +1,55 @@
+package com.androidtel.telemetry_library.core
+
+import android.content.Context
+import com.androidtel.telemetry_library.core.models.TelemetryBatch
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+
+/**
+ * Unit tests for OfflineBatchStorage — the 200-envelope, drop-oldest, Mutex-serialized store (D9).
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [28], manifest = Config.NONE)
+class OfflineBatchStorageTest {
+
+    private lateinit var context: Context
+    private lateinit var storage: OfflineBatchStorage
+
+    @Before
+    fun setUp() {
+        context = RuntimeEnvironment.getApplication()
+        storage = OfflineBatchStorage(context)
+        runBlocking { storage.clearAllBatches() }
+    }
+
+    private fun batch(id: String): TelemetryBatch =
+        TelemetryBatch(id = id, batchSize = 0, timestamp = "t", events = emptyList())
+
+    @Test
+    fun `caps at MAX_ENVELOPES dropping the oldest`() = runBlocking {
+        repeat(OfflineBatchStorage.MAX_ENVELOPES + 1) { storage.storeBatch(batch("b$it")) }
+
+        val stored = storage.getStoredBatches()
+        assertEquals(OfflineBatchStorage.MAX_ENVELOPES, stored.size)
+        // b0 (first/oldest) evicted; oldest survivor is b1, newest is the last stored.
+        assertEquals("b1", stored.first().id)
+        assertEquals("b${OfflineBatchStorage.MAX_ENVELOPES}", stored.last().id)
+    }
+
+    @Test
+    fun `concurrent stores do not lose batches`() = runBlocking {
+        val n = 50
+        (0 until n).map { i -> async { storage.storeBatch(batch("c$i")) } }.awaitAll()
+
+        // Without the Mutex, racing read-modify-write blobs would drop batches (last-write-wins).
+        assertEquals(n, storage.getStoredBatches().size)
+    }
+}

--- a/telemetry_library/src/test/java/com/androidtel/telemetry_library/core/TelemetryIdValidationTest.kt
+++ b/telemetry_library/src/test/java/com/androidtel/telemetry_library/core/TelemetryIdValidationTest.kt
@@ -20,7 +20,7 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 import java.lang.reflect.Field
-import java.util.concurrent.ConcurrentLinkedQueue
+import com.androidtel.telemetry_library.core.CountedEventQueue
 
 /**
  * Test suite to verify that telemetry data is ONLY sent when device ID and user ID
@@ -112,8 +112,8 @@ class TelemetryIdValidationTest {
         )
         // Note: setIdsInitialized(true) is deliberately NOT called.
 
-        val eventQueue = ConcurrentLinkedQueue<TelemetryEvent>()
-        eventQueue.add(mockk(relaxed = true))
+        val eventQueue = CountedEventQueue()
+        eventQueue.enqueue(mockk(relaxed = true))
 
         // When: a send is forced while IDs are not initialized
         service.sendBatch(eventQueue, forceSend = true, flushOffline = false)

--- a/telemetry_library/src/test/java/com/androidtel/telemetry_library/core/services/BatchProcessingServiceTest.kt
+++ b/telemetry_library/src/test/java/com/androidtel/telemetry_library/core/services/BatchProcessingServiceTest.kt
@@ -15,7 +15,7 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
-import java.util.concurrent.ConcurrentLinkedQueue
+import com.androidtel.telemetry_library.core.CountedEventQueue
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
@@ -66,7 +66,7 @@ class BatchProcessingServiceTest {
         )
         fastService.setIdsInitialized(true)
 
-        val queue = ConcurrentLinkedQueue<TelemetryEvent>().apply { add(mockk(relaxed = true)) } // 1 < 50
+        val queue = CountedEventQueue().apply { enqueue(mockk(relaxed = true)) } // 1 < 50
         coEvery { httpClient.sendBatch(any()) } returns Result.success(Unit)
 
         val fired = CountDownLatch(1)
@@ -90,7 +90,7 @@ class BatchProcessingServiceTest {
 
         val fired = CountDownLatch(1)
         fastService.initialize(onFlush = {
-            runBlocking { fastService.sendBatch(ConcurrentLinkedQueue(), forceSend = true) }
+            runBlocking { fastService.sendBatch(CountedEventQueue(), forceSend = true) }
             fired.countDown()
         })
 
@@ -122,8 +122,8 @@ class BatchProcessingServiceTest {
 
     @Test
     fun `test sendBatch skips when IDs not initialized`() = runTest {
-        val eventQueue = ConcurrentLinkedQueue<TelemetryEvent>()
-        repeat(50) { eventQueue.add(mockk(relaxed = true)) }
+        val eventQueue = CountedEventQueue()
+        repeat(50) { eventQueue.enqueue(mockk(relaxed = true)) }
         
         service.sendBatch(eventQueue)
         
@@ -135,8 +135,8 @@ class BatchProcessingServiceTest {
     fun `test sendBatch sends when IDs initialized and batch size met`() = runTest {
         service.setIdsInitialized(true)
         
-        val eventQueue = ConcurrentLinkedQueue<TelemetryEvent>()
-        repeat(50) { eventQueue.add(mockk(relaxed = true)) }
+        val eventQueue = CountedEventQueue()
+        repeat(50) { eventQueue.enqueue(mockk(relaxed = true)) }
         
         coEvery { httpClient.sendBatch(any()) } returns Result.success(Unit)
         
@@ -150,8 +150,8 @@ class BatchProcessingServiceTest {
     fun `test sendBatch with forceSend ignores batch size`() = runTest {
         service.setIdsInitialized(true)
         
-        val eventQueue = ConcurrentLinkedQueue<TelemetryEvent>()
-        repeat(10) { eventQueue.add(mockk(relaxed = true)) }
+        val eventQueue = CountedEventQueue()
+        repeat(10) { eventQueue.enqueue(mockk(relaxed = true)) }
         
         coEvery { httpClient.sendBatch(any()) } returns Result.success(Unit)
         
@@ -165,8 +165,8 @@ class BatchProcessingServiceTest {
     fun `test sendBatch does not send when below batch size and not forced`() = runTest {
         service.setIdsInitialized(true)
         
-        val eventQueue = ConcurrentLinkedQueue<TelemetryEvent>()
-        repeat(25) { eventQueue.add(mockk(relaxed = true)) }
+        val eventQueue = CountedEventQueue()
+        repeat(25) { eventQueue.enqueue(mockk(relaxed = true)) }
         
         service.sendBatch(eventQueue, forceSend = false)
         
@@ -178,8 +178,8 @@ class BatchProcessingServiceTest {
     fun `test sendBatch stores offline on failure`() = runTest {
         service.setIdsInitialized(true)
         
-        val eventQueue = ConcurrentLinkedQueue<TelemetryEvent>()
-        repeat(50) { eventQueue.add(mockk(relaxed = true)) }
+        val eventQueue = CountedEventQueue()
+        repeat(50) { eventQueue.enqueue(mockk(relaxed = true)) }
         
         coEvery { httpClient.sendBatch(any()) } returns Result.failure(Exception("Network error"))
         
@@ -193,8 +193,8 @@ class BatchProcessingServiceTest {
     fun `test sendBatch does not store offline when flushOffline is false`() = runTest {
         service.setIdsInitialized(true)
         
-        val eventQueue = ConcurrentLinkedQueue<TelemetryEvent>()
-        repeat(50) { eventQueue.add(mockk(relaxed = true)) }
+        val eventQueue = CountedEventQueue()
+        repeat(50) { eventQueue.enqueue(mockk(relaxed = true)) }
         
         coEvery { httpClient.sendBatch(any()) } returns Result.failure(Exception("Network error"))
         
@@ -208,8 +208,8 @@ class BatchProcessingServiceTest {
     fun `test sendBatch includes location when provided`() = runTest {
         service.setIdsInitialized(true)
         
-        val eventQueue = ConcurrentLinkedQueue<TelemetryEvent>()
-        repeat(50) { eventQueue.add(mockk(relaxed = true)) }
+        val eventQueue = CountedEventQueue()
+        repeat(50) { eventQueue.enqueue(mockk(relaxed = true)) }
         
         val location = "37.7749,-122.4194"
         var capturedBatch: TelemetryBatch? = null
@@ -228,7 +228,7 @@ class BatchProcessingServiceTest {
     fun `test sendBatch with empty queue does nothing`() = runTest {
         service.setIdsInitialized(true)
         
-        val eventQueue = ConcurrentLinkedQueue<TelemetryEvent>()
+        val eventQueue = CountedEventQueue()
         
         service.sendBatch(eventQueue, forceSend = true)
         
@@ -287,8 +287,8 @@ class BatchProcessingServiceTest {
     fun `test triggerBatchSend launches coroutine`() {
         service.setIdsInitialized(true)
         
-        val eventQueue = ConcurrentLinkedQueue<TelemetryEvent>()
-        repeat(50) { eventQueue.add(mockk(relaxed = true)) }
+        val eventQueue = CountedEventQueue()
+        repeat(50) { eventQueue.enqueue(mockk(relaxed = true)) }
         
         coEvery { httpClient.sendBatch(any()) } returns Result.success(Unit)
         
@@ -301,8 +301,8 @@ class BatchProcessingServiceTest {
     fun `test triggerBatchSend with location`() {
         service.setIdsInitialized(true)
         
-        val eventQueue = ConcurrentLinkedQueue<TelemetryEvent>()
-        repeat(50) { eventQueue.add(mockk(relaxed = true)) }
+        val eventQueue = CountedEventQueue()
+        repeat(50) { eventQueue.enqueue(mockk(relaxed = true)) }
         
         coEvery { httpClient.sendBatch(any()) } returns Result.success(Unit)
         
@@ -312,48 +312,41 @@ class BatchProcessingServiceTest {
     }
 
     @Test
-    fun `test restoreOfflineBatches adds events to queue`() = runTest {
-        val event1 = mockk<TelemetryEvent>(relaxed = true)
-        val event2 = mockk<TelemetryEvent>(relaxed = true)
-        val event3 = mockk<TelemetryEvent>(relaxed = true)
-        
-        val batch1 = mockk<TelemetryBatch>(relaxed = true)
-        val batch2 = mockk<TelemetryBatch>(relaxed = true)
-        
-        every { batch1.id } returns "batch-1"
-        every { batch1.events } returns listOf(event1, event2)
-        every { batch2.id } returns "batch-2"
-        every { batch2.events } returns listOf(event3)
-        
-        coEvery { offlineStorage.getStoredBatches() } returns listOf(batch1, batch2)
-        
-        val eventQueue = ConcurrentLinkedQueue<TelemetryEvent>()
-        service.restoreOfflineBatches(eventQueue)
-        
-        assertEquals(3, eventQueue.size)
+    fun `sendStoredBatches replays at most REPLAY_BATCH_LIMIT oldest per cycle`() = runTest {
+        // 25 stored envelopes, oldest-first.
+        val batches = (1..25).map { i ->
+            mockk<TelemetryBatch>(relaxed = true).also { every { it.id } returns "batch-$i" }
+        }
+        coEvery { offlineStorage.getStoredBatches() } returns batches
+        coEvery { httpClient.sendBatch(any()) } returns Result.success(Unit)
+
+        service.sendStoredBatches()
+
+        // Only the 10 oldest are sent + removed this cycle; the timer paces the rest.
+        coVerify(exactly = 10) { httpClient.sendBatch(any()) }
+        coVerify { offlineStorage.removeBatch("batch-1") }
+        coVerify { offlineStorage.removeBatch("batch-10") }
+        coVerify(exactly = 0) { offlineStorage.removeBatch("batch-11") }
+    }
+
+    @Test
+    fun `sendStoredBatches stops on first failure`() = runTest {
+        val batches = (1..25).map { i ->
+            mockk<TelemetryBatch>(relaxed = true).also { every { it.id } returns "batch-$i" }
+        }
+        coEvery { offlineStorage.getStoredBatches() } returns batches
+        // Fail on the 3rd send.
+        coEvery { httpClient.sendBatch(batches[0]) } returns Result.success(Unit)
+        coEvery { httpClient.sendBatch(batches[1]) } returns Result.success(Unit)
+        coEvery { httpClient.sendBatch(batches[2]) } returns Result.failure(Exception("collector down"))
+
+        service.sendStoredBatches()
+
+        // Sends 1, 2, then 3 (which fails) → stop. 23 remain.
+        coVerify(exactly = 3) { httpClient.sendBatch(any()) }
         coVerify { offlineStorage.removeBatch("batch-1") }
         coVerify { offlineStorage.removeBatch("batch-2") }
-    }
-
-    @Test
-    fun `test restoreOfflineBatches with no stored batches`() = runTest {
-        coEvery { offlineStorage.getStoredBatches() } returns emptyList()
-        
-        val eventQueue = ConcurrentLinkedQueue<TelemetryEvent>()
-        service.restoreOfflineBatches(eventQueue)
-        
-        assertTrue(eventQueue.isEmpty())
-    }
-
-    @Test
-    fun `test restoreOfflineBatches handles errors gracefully`() = runTest {
-        coEvery { offlineStorage.getStoredBatches() } throws Exception("Storage error")
-        
-        val eventQueue = ConcurrentLinkedQueue<TelemetryEvent>()
-        service.restoreOfflineBatches(eventQueue)
-        
-        // Should not throw exception
-        assertTrue(eventQueue.isEmpty())
+        coVerify(exactly = 0) { offlineStorage.removeBatch("batch-3") }
     }
 
     @Test
@@ -362,10 +355,10 @@ class BatchProcessingServiceTest {
         val event2 = mockk<TelemetryEvent>(relaxed = true)
         val event3 = mockk<TelemetryEvent>(relaxed = true)
         
-        val eventQueue = ConcurrentLinkedQueue<TelemetryEvent>()
-        eventQueue.add(event1)
-        eventQueue.add(event2)
-        eventQueue.add(event3)
+        val eventQueue = CountedEventQueue()
+        eventQueue.enqueue(event1)
+        eventQueue.enqueue(event2)
+        eventQueue.enqueue(event3)
         
         service.flushToOfflineStorage(eventQueue)
         
@@ -375,7 +368,7 @@ class BatchProcessingServiceTest {
 
     @Test
     fun `test flushToOfflineStorage with empty queue does nothing`() = runTest {
-        val eventQueue = ConcurrentLinkedQueue<TelemetryEvent>()
+        val eventQueue = CountedEventQueue()
         
         service.flushToOfflineStorage(eventQueue)
         
@@ -384,8 +377,8 @@ class BatchProcessingServiceTest {
 
     @Test
     fun `test flushToOfflineStorage handles errors gracefully`() = runTest {
-        val eventQueue = ConcurrentLinkedQueue<TelemetryEvent>()
-        eventQueue.add(mockk(relaxed = true))
+        val eventQueue = CountedEventQueue()
+        eventQueue.enqueue(mockk(relaxed = true))
         
         coEvery { offlineStorage.storeBatch(any()) } throws Exception("Storage error")
         
@@ -437,8 +430,8 @@ class BatchProcessingServiceTest {
     fun `test sendBatch creates batch with correct size`() = runTest {
         service.setIdsInitialized(true)
         
-        val eventQueue = ConcurrentLinkedQueue<TelemetryEvent>()
-        repeat(75) { eventQueue.add(mockk(relaxed = true)) }
+        val eventQueue = CountedEventQueue()
+        repeat(75) { eventQueue.enqueue(mockk(relaxed = true)) }
         
         var capturedBatch: TelemetryBatch? = null
         coEvery { httpClient.sendBatch(any()) } answers {
@@ -456,8 +449,8 @@ class BatchProcessingServiceTest {
     fun `test sendBatch creates batch with timestamp`() = runTest {
         service.setIdsInitialized(true)
         
-        val eventQueue = ConcurrentLinkedQueue<TelemetryEvent>()
-        repeat(50) { eventQueue.add(mockk(relaxed = true)) }
+        val eventQueue = CountedEventQueue()
+        repeat(50) { eventQueue.enqueue(mockk(relaxed = true)) }
         
         var capturedBatch: TelemetryBatch? = null
         coEvery { httpClient.sendBatch(any()) } answers {
@@ -480,8 +473,8 @@ class BatchProcessingServiceTest {
         
         val jobs = (1..5).map { threadNum ->
             testScope.launch {
-                val eventQueue = ConcurrentLinkedQueue<TelemetryEvent>()
-                repeat(50) { eventQueue.add(mockk(relaxed = true)) }
+                val eventQueue = CountedEventQueue()
+                repeat(50) { eventQueue.enqueue(mockk(relaxed = true)) }
                 service.sendBatch(eventQueue)
             }
         }
@@ -495,11 +488,11 @@ class BatchProcessingServiceTest {
     fun `test batch processing with mixed success and failure`() = runTest {
         service.setIdsInitialized(true)
         
-        val eventQueue1 = ConcurrentLinkedQueue<TelemetryEvent>()
-        val eventQueue2 = ConcurrentLinkedQueue<TelemetryEvent>()
+        val eventQueue1 = CountedEventQueue()
+        val eventQueue2 = CountedEventQueue()
         repeat(50) { 
-            eventQueue1.add(mockk(relaxed = true))
-            eventQueue2.add(mockk(relaxed = true))
+            eventQueue1.enqueue(mockk(relaxed = true))
+            eventQueue2.enqueue(mockk(relaxed = true))
         }
         
         coEvery { httpClient.sendBatch(any()) } returnsMany listOf(
@@ -518,8 +511,8 @@ class BatchProcessingServiceTest {
     fun `test sendBatch logs appropriate messages`() = runTest {
         service.setIdsInitialized(true)
         
-        val eventQueue = ConcurrentLinkedQueue<TelemetryEvent>()
-        repeat(50) { eventQueue.add(mockk(relaxed = true)) }
+        val eventQueue = CountedEventQueue()
+        repeat(50) { eventQueue.enqueue(mockk(relaxed = true)) }
         
         coEvery { httpClient.sendBatch(any()) } returns Result.success(Unit)
         
@@ -529,17 +522,19 @@ class BatchProcessingServiceTest {
     }
 
     @Test
-    fun `test large batch processing`() = runTest {
+    fun `test large burst is capped at MAX_EVENTS drop-oldest`() = runTest {
         service.setIdsInitialized(true)
-        
-        val eventQueue = ConcurrentLinkedQueue<TelemetryEvent>()
-        repeat(1000) { eventQueue.add(mockk(relaxed = true)) }
-        
+
+        // A 1000-event burst is bounded to MAX_EVENTS (500) by drop-oldest before it ever sends.
+        val eventQueue = CountedEventQueue()
+        repeat(1000) { eventQueue.enqueue(mockk(relaxed = true)) }
+        assertEquals(CountedEventQueue.MAX_EVENTS, eventQueue.size)
+
         coEvery { httpClient.sendBatch(any()) } returns Result.success(Unit)
-        
+
         service.sendBatch(eventQueue, forceSend = true)
-        
-        coVerify { httpClient.sendBatch(match { it.batchSize == 1000 }) }
+
+        coVerify { httpClient.sendBatch(match { it.batchSize == CountedEventQueue.MAX_EVENTS }) }
         assertTrue(eventQueue.isEmpty())
     }
 
@@ -547,8 +542,8 @@ class BatchProcessingServiceTest {
     fun `test batch with location and forced send`() = runTest {
         service.setIdsInitialized(true)
         
-        val eventQueue = ConcurrentLinkedQueue<TelemetryEvent>()
-        repeat(10) { eventQueue.add(mockk(relaxed = true)) }
+        val eventQueue = CountedEventQueue()
+        repeat(10) { eventQueue.enqueue(mockk(relaxed = true)) }
         
         var capturedBatch: TelemetryBatch? = null
         coEvery { httpClient.sendBatch(any()) } answers {
@@ -584,22 +579,12 @@ class BatchProcessingServiceTest {
     }
 
     @Test
-    fun `test restore and flush operations maintain data integrity`() = runTest {
-        val originalEvents = (1..10).map { mockk<TelemetryEvent>(relaxed = true) }
-        
-        val batch = mockk<TelemetryBatch>(relaxed = true)
-        every { batch.id } returns "test-batch"
-        every { batch.events } returns originalEvents
-        
-        coEvery { offlineStorage.getStoredBatches() } returns listOf(batch)
-        
-        val eventQueue = ConcurrentLinkedQueue<TelemetryEvent>()
-        service.restoreOfflineBatches(eventQueue)
-        
-        assertEquals(10, eventQueue.size)
-        
+    fun `test flush drains the whole queue into one offline batch`() = runTest {
+        val eventQueue = CountedEventQueue()
+        repeat(10) { eventQueue.enqueue(mockk(relaxed = true)) }
+
         service.flushToOfflineStorage(eventQueue)
-        
+
         coVerify { offlineStorage.storeBatch(match { it.batchSize == 10 }) }
         assertTrue(eventQueue.isEmpty())
     }


### PR DESCRIPTION
Closes #51.

Bound every client-side telemetry buffer so a burst or long offline period can't exhaust memory or storage. Implements `docs/specs/bounded-buffers-eviction.md` (hub decision D9).

## Changes
- **Offline store** — 200-envelope drop-oldest cap, all mutations serialized with a `Mutex` (kills the read-modify-write race in `storeBatch`/`removeBatch`). SharedPreferences kept; dead Room deps removed from `build.gradle.kts` **and** `libs.versions.toml`.
- **In-memory event queue** — new `CountedEventQueue`: 500-event drop-oldest cap with an `AtomicInteger` size, avoiding O(n²) enqueue from `ConcurrentLinkedQueue.size`.
- **Replay throttling** — `sendStoredBatches` drains ≤10 oldest envelopes per flush tick and stops on the first failure; wired into the existing flush timer (no new scheduler).
- **`restoreOfflineBatches` deleted** — replay now goes offline-store → network directly, never back through the capped queue. Crash path enqueues through the cap.
- Refreshed `CLAUDE.md` (Room no longer a dependency).

## Acceptance criteria
- [x] Offline store caps at 200, drop-oldest; seed-past-cap test confirms eviction
- [x] Event queue caps at 500, drop-oldest
- [x] One flush cycle sends ≤10 oldest envelopes; injected failure at #3 stops replay
- [x] `restoreOfflineBatches` deleted; Room deps removed

## Tests
New: `CountedEventQueueTest` (cap/FIFO), `OfflineBatchStorageTest` (cap + concurrent-store atomicity). Existing `BatchProcessingServiceTest` updated with replay ≤10 + stop-on-failure-at-#3 cases.

487 unit tests pass (0 failures) across all classes except the 3 pre-existing `MockWebServer.takeRequest`-hang classes (`CrashRetryManager`/`TelemetryHttpClient`/`UnifiedEnvelope`), which are unrelated to this change. `./gradlew :telemetry_library:assembleRelease` clean.