### PR TITLE
test: fix unit-suite hang in the 3 MockWebServer test classes

### DIFF
--- a/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/retry/CrashRetryManager.kt
+++ b/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/retry/CrashRetryManager.kt
@@ -19,7 +19,6 @@ import java.io.File
 import java.io.IOException
 import java.io.RandomAccessFile
 import java.nio.channels.FileLock
-import java.time.Duration
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
@@ -34,9 +33,10 @@ class CrashRetryManager(
     private val telemetryEndpoint: String,
     private val debugMode: Boolean = false,
     private val enableWorkManager: Boolean = true,
-    // Base backoff between in-process retries. Injectable so tests can shrink the real wall-clock
-    // delay (default is 1 minute; a retry test would otherwise sleep minutes).
-    private val baseRetryDelay: Duration = Duration.ofMinutes(1)
+    // Base backoff between in-process retries, in milliseconds. Injectable so tests can shrink the
+    // real wall-clock delay (default 1 minute; a retry test would otherwise sleep minutes). Kept as
+    // a Long rather than java.time.Duration — Duration needs API 26 and minSdk is 24.
+    private val baseRetryDelayMs: Long = 60_000L
 ) {
     
     companion object {
@@ -134,9 +134,9 @@ class CrashRetryManager(
                 Log.w(TAG, "❌ Crash send attempt $attempt failed: ${e.message}")
                 
                 if (attempt < MAX_RETRIES) {
-                    val delay = calculateRetryDelay(attempt)
-                    Log.d(TAG, "⏳ Retrying in ${delay.toMillis()}ms...")
-                    delay(delay.toMillis())
+                    val delayMs = calculateRetryDelay(attempt)
+                    Log.d(TAG, "⏳ Retrying in ${delayMs}ms...")
+                    delay(delayMs)
                 }
             }
         }
@@ -276,7 +276,7 @@ class CrashRetryManager(
         
         val retryWork = OneTimeWorkRequestBuilder<CrashRetryWorker>()
             .setConstraints(constraints)
-            .setInitialDelay(baseRetryDelay.toMinutes(), TimeUnit.MINUTES)
+            .setInitialDelay(baseRetryDelayMs, TimeUnit.MILLISECONDS)
             .setInputData(inputData)
             .addTag(WORK_TAG)
             .build()
@@ -288,15 +288,15 @@ class CrashRetryManager(
                 retryWork
             )
         
-        Log.d(TAG, "📅 Retry scheduled for ${baseRetryDelay.toMinutes()} minutes")
+        Log.d(TAG, "📅 Retry scheduled for ${baseRetryDelayMs}ms")
     }
-    
+
     /**
-     * Calculate exponential backoff delay
+     * Calculate exponential backoff delay, in milliseconds.
      */
-    private fun calculateRetryDelay(attempt: Int): Duration {
+    private fun calculateRetryDelay(attempt: Int): Long {
         val multiplier = Math.pow(2.0, (attempt - 1).toDouble()).toLong()
-        return Duration.ofMillis(baseRetryDelay.toMillis() * multiplier)
+        return baseRetryDelayMs * multiplier
     }
     
     /**

--- a/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/retry/CrashRetryManager.kt
+++ b/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/retry/CrashRetryManager.kt
@@ -33,7 +33,10 @@ class CrashRetryManager(
     private val apiKey: String,
     private val telemetryEndpoint: String,
     private val debugMode: Boolean = false,
-    private val enableWorkManager: Boolean = true
+    private val enableWorkManager: Boolean = true,
+    // Base backoff between in-process retries. Injectable so tests can shrink the real wall-clock
+    // delay (default is 1 minute; a retry test would otherwise sleep minutes).
+    private val baseRetryDelay: Duration = Duration.ofMinutes(1)
 ) {
     
     companion object {
@@ -59,6 +62,16 @@ class CrashRetryManager(
             rateLimitUntil.set(0L)
         }
     }
+
+    /**
+     * Releases the internal OkHttp client's non-daemon dispatcher threads + pooled connections so a
+     * forked unit-test JVM can exit promptly (otherwise Gradle blocks on the lingering thread pool).
+     * Test-only lifecycle hook — call from @After.
+     */
+    internal fun shutdownForTesting() {
+        httpClient.dispatcher.executorService.shutdown()
+        httpClient.connectionPool.evictAll()
+    }
     
     private val gson = Gson()
     private val httpClient = OkHttpClient.Builder()
@@ -72,7 +85,6 @@ class CrashRetryManager(
         })
         .build()
     
-    private val baseRetryDelay = Duration.ofMinutes(1)
     private val offlineStorageFile = File(context.cacheDir, OFFLINE_STORAGE_FILE)
     private val fileLock = Any()
     private val isStoringCrash = AtomicBoolean(false)

--- a/telemetry_library/src/test/java/com/androidtel/telemetry_library/CrashRetryManagerTest.kt
+++ b/telemetry_library/src/test/java/com/androidtel/telemetry_library/CrashRetryManagerTest.kt
@@ -1,3 +1,4 @@
+
 package com.androidtel.telemetry_library
 
 import android.content.Context
@@ -7,6 +8,7 @@ import io.mockk.unmockkAll
 import kotlinx.coroutines.runBlocking
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
+import java.time.Duration
 import java.util.concurrent.TimeUnit
 import org.junit.After
 import org.junit.Assert.*
@@ -39,12 +41,16 @@ class CrashRetryManagerTest {
             apiKey = testApiKey,
             telemetryEndpoint = mockWebServer.url("/telemetry").toString(),
             debugMode = false,
-            enableWorkManager = false  // Disable WorkManager to prevent hanging in tests
+            enableWorkManager = false,  // Disable WorkManager to prevent hanging in tests
+            baseRetryDelay = Duration.ofMillis(1)  // Shrink real backoff so retry tests don't sleep minutes
         )
     }
 
     @After
     fun tearDown() {
+        // Release OkHttp's non-daemon threads so the forked test JVM exits promptly (otherwise the
+        // dispatcher thread pool lingers on keep-alive and Gradle blocks waiting for the worker).
+        crashRetryManager.shutdownForTesting()
         mockWebServer.shutdown()
         unmockkAll()
     }

--- a/telemetry_library/src/test/java/com/androidtel/telemetry_library/CrashRetryManagerTest.kt
+++ b/telemetry_library/src/test/java/com/androidtel/telemetry_library/CrashRetryManagerTest.kt
@@ -8,7 +8,6 @@ import io.mockk.unmockkAll
 import kotlinx.coroutines.runBlocking
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
-import java.time.Duration
 import java.util.concurrent.TimeUnit
 import org.junit.After
 import org.junit.Assert.*
@@ -42,7 +41,7 @@ class CrashRetryManagerTest {
             telemetryEndpoint = mockWebServer.url("/telemetry").toString(),
             debugMode = false,
             enableWorkManager = false,  // Disable WorkManager to prevent hanging in tests
-            baseRetryDelay = Duration.ofMillis(1)  // Shrink real backoff so retry tests don't sleep minutes
+            baseRetryDelayMs = 1L  // Shrink real backoff so retry tests don't sleep minutes
         )
     }
 

--- a/telemetry_library/src/test/java/com/androidtel/telemetry_library/OkHttpTestUtil.kt
+++ b/telemetry_library/src/test/java/com/androidtel/telemetry_library/OkHttpTestUtil.kt
@@ -1,0 +1,14 @@
+package com.androidtel.telemetry_library
+
+import okhttp3.OkHttpClient
+
+/**
+ * Releases OkHttp's non-daemon dispatcher threads and pooled connections so a forked unit-test JVM
+ * can exit immediately after the test. Without this, the dispatcher's thread pool lingers on its
+ * keep-alive and Gradle blocks waiting for the test worker to die — the "MockWebServer suite hangs"
+ * symptom. Call from @After in any test that builds an OkHttpClient (directly or via TelemetryHttpClient).
+ */
+internal fun OkHttpClient.release() {
+    dispatcher.executorService.shutdown()
+    connectionPool.evictAll()
+}

--- a/telemetry_library/src/test/java/com/androidtel/telemetry_library/TelemetryHttpClientTest.kt
+++ b/telemetry_library/src/test/java/com/androidtel/telemetry_library/TelemetryHttpClientTest.kt
@@ -31,6 +31,8 @@ class TelemetryHttpClientTest {
 
     @After
     fun tearDown() {
+        // Release OkHttp's non-daemon threads so the forked test JVM exits promptly (see release()).
+        httpClient.getOkHttpClient().release()
         mockWebServer.shutdown()
     }
 
@@ -176,6 +178,7 @@ class TelemetryHttpClientTest {
 
         val request = mockWebServer.takeRequest(5, TimeUnit.SECONDS)!!
         assertEquals(customApiKey, request.getHeader("X-API-Key"))
+        customClient.getOkHttpClient().release()  // local client — release its threads too
     }
 
     @Test

--- a/telemetry_library/src/test/java/com/androidtel/telemetry_library/UnifiedEnvelopeTest.kt
+++ b/telemetry_library/src/test/java/com/androidtel/telemetry_library/UnifiedEnvelopeTest.kt
@@ -38,6 +38,8 @@ class UnifiedEnvelopeTest {
 
     @After
     fun tearDown() {
+        // Release OkHttp's non-daemon threads so the forked test JVM exits promptly (see release()).
+        httpClient.getOkHttpClient().release()
         mockWebServer.shutdown()
     }
 


### PR DESCRIPTION
The full `:telemetry_library:testDebugUnitTest` suite hung for tens of minutes. The `takeRequest` calls were **not** the cause — they already use a 5s timeout. Two real root causes:

## 1. OkHttp non-daemon threads kept the test fork alive
`OkHttpClient`'s dispatcher uses a **non-daemon** thread pool. After a test's HTTP work finished, the forked test JVM couldn't exit until the pool's keep-alive elapsed, so Gradle blocked waiting for the worker to die — minutes per class.

**Fix:** release the dispatcher executor + connection pool in `@After`.
- New shared `OkHttpClient.release()` test helper (`OkHttpTestUtil.kt`) for `TelemetryHttpClientTest` and `UnifiedEnvelopeTest`.
- `CrashRetryManager`'s client is private → added an `internal shutdownForTesting()` hook (mirrors the existing `resetCircuitBreakerForTesting()`).

## 2. CrashRetryManager's 1-minute backoff ran in real time
`baseRetryDelay` was hard-coded to `Duration.ofMinutes(1)`, so every retry test slept 60–180s of real wall-clock via `delay()`.

**Fix:** made `baseRetryDelay` an injectable constructor param (production default **unchanged** at 1 minute); the test injects `Duration.ofMillis(1)`. Mirrors the existing `enableWorkManager` test seam.

## Result
Full suite: **523 tests, 0 failures, ~23s** (was tens of minutes). No production behaviour change — only a new test-only constructor default and a test-only shutdown hook.