### PR TITLE
feat(#52): self-describing ID format <kind>_<epochMs>_<16hex>_android

### DIFF
--- a/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/ids/IdGenerator.kt
+++ b/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/ids/IdGenerator.kt
@@ -10,9 +10,7 @@ class IdGenerator {
         private const val PREFS_NAME = "edge_telemetry_ids"
         private const val KEY_DEVICE_ID = "device_id"
         private const val KEY_USER_ID = "edge_rum_user_id"
-        private const val CHARS = "abcdefghijklmnopqrstuvwxyz0123456789"
-        private const val RANDOM_LENGTH = 8
-        
+
         private val secureRandom = SecureRandom()
     }
     
@@ -34,7 +32,7 @@ class IdGenerator {
         
         return synchronized(lock) {
             sharedPrefs.getString(KEY_DEVICE_ID, null) ?: run {
-                val deviceId = generateId()
+                val deviceId = generateId("device")
                 sharedPrefs.edit().putString(KEY_DEVICE_ID, deviceId).apply()
                 deviceId
             }
@@ -46,7 +44,7 @@ class IdGenerator {
     }
     
     fun generateSessionId(): String {
-        return generateId()
+        return generateId("session")
     }
     
     fun getUserId(): String {
@@ -54,26 +52,28 @@ class IdGenerator {
         
         return synchronized(lock) {
             sharedPrefs.getString(KEY_USER_ID, null) ?: run {
-                val userId = generateId()
+                val userId = generateId("user")
                 sharedPrefs.edit().putString(KEY_USER_ID, userId).apply()
                 userId
             }
         }
     }
     
-    private fun generateId(): String {
-        val timestamp = System.currentTimeMillis()
-        val randomString = generateRandomString(RANDOM_LENGTH)
-        return "${timestamp}_${randomString}"
+    private fun generateId(kind: String): String {
+        return "${kind}_${System.currentTimeMillis()}_${hex16()}_android"
     }
-    
-    private fun generateRandomString(length: Int): String {
-        val chars = CharArray(length)
+
+    // 16 lowercase hex chars (64 bits) from crypto RNG.
+    private fun hex16(): String {
+        val bytes = ByteArray(8)
         synchronized(secureRandom) {
-            for (i in 0 until length) {
-                chars[i] = CHARS[secureRandom.nextInt(CHARS.length)]
-            }
+            secureRandom.nextBytes(bytes)
         }
-        return String(chars)
+        val sb = StringBuilder(16)
+        for (b in bytes) {
+            sb.append(Character.forDigit((b.toInt() shr 4) and 0xF, 16))
+            sb.append(Character.forDigit(b.toInt() and 0xF, 16))
+        }
+        return sb.toString()
     }
 }

--- a/telemetry_library/src/test/java/com/androidtel/telemetry_library/core/TelemetryIdValidationTest.kt
+++ b/telemetry_library/src/test/java/com/androidtel/telemetry_library/core/TelemetryIdValidationTest.kt
@@ -242,7 +242,7 @@ class TelemetryIdValidationTest {
 
         // Then: Device ID should be generated and persisted
         assertNotNull("Device ID should be generated", deviceId)
-        assertTrue("Device ID should match format", deviceId.matches(Regex("""\d{13}_[a-z0-9]{8}""")))
+        assertTrue("Device ID should match format", deviceId.matches(Regex("""(device|user|session)_\d+_[0-9a-f]{16}_android""")))
         verify { mockEditor.putString("device_id", any()) }
     }
 
@@ -261,7 +261,7 @@ class TelemetryIdValidationTest {
 
         // Then: User ID should be generated and persisted
         assertNotNull("User ID should be generated", userId)
-        assertTrue("User ID should match format", userId.matches(Regex("""\d{13}_[a-z0-9]{8}""")))
+        assertTrue("User ID should match format", userId.matches(Regex("""(device|user|session)_\d+_[0-9a-f]{16}_android""")))
         verify { mockEditor.putString("edge_rum_user_id", any()) }
     }
 

--- a/telemetry_library/src/test/java/com/androidtel/telemetry_library/core/ids/IdConsistencyTest.kt
+++ b/telemetry_library/src/test/java/com/androidtel/telemetry_library/core/ids/IdConsistencyTest.kt
@@ -58,7 +58,7 @@ class IdConsistencyTest {
         val sessionId2 = sessionManager.getCurrentSessionId()
         
         assertEquals("SessionManager must return same session ID", sessionId1, sessionId2)
-        assertTrue("Session ID must match format", sessionId1.matches(Regex("""\d{13}_[a-z0-9]{8}""")))
+        assertTrue("Session ID must match format", sessionId1.matches(Regex("""(device|user|session)_\d+_[0-9a-f]{16}_android""")))
     }
 
     @Test
@@ -132,9 +132,9 @@ class IdConsistencyTest {
         val directSessionId = idGenerator.generateSessionId()
         
         assertTrue("SessionManager session ID must match IdGenerator format", 
-            sessionId.matches(Regex("""\d{13}_[a-z0-9]{8}""")))
+            sessionId.matches(Regex("""(device|user|session)_\d+_[0-9a-f]{16}_android""")))
         assertTrue("Direct IdGenerator session ID must match format", 
-            directSessionId.matches(Regex("""\d{13}_[a-z0-9]{8}""")))
+            directSessionId.matches(Regex("""(device|user|session)_\d+_[0-9a-f]{16}_android""")))
     }
 
     @Test
@@ -176,9 +176,9 @@ class IdConsistencyTest {
         
         assertNotEquals("New session must have different ID", sessionId1, sessionId2)
         assertTrue("First session ID must match format", 
-            sessionId1.matches(Regex("""\d{13}_[a-z0-9]{8}""")))
+            sessionId1.matches(Regex("""(device|user|session)_\d+_[0-9a-f]{16}_android""")))
         assertTrue("Second session ID must match format", 
-            sessionId2.matches(Regex("""\d{13}_[a-z0-9]{8}""")))
+            sessionId2.matches(Regex("""(device|user|session)_\d+_[0-9a-f]{16}_android""")))
     }
 
     @Test
@@ -192,7 +192,7 @@ class IdConsistencyTest {
         val deviceId = deviceInfo["device.id"]
         val userId = userProfileManager.getUserId()
         
-        val idFormatRegex = Regex("""\d{13}_[a-z0-9]{8}""")
+        val idFormatRegex = Regex("""(device|user|session)_\d+_[0-9a-f]{16}_android""")
         
         assertTrue("Session ID must match format: $sessionId", idFormatRegex.matches(sessionId))
         assertTrue("Device ID must match format: $deviceId", deviceId?.let { idFormatRegex.matches(it) } ?: false)
@@ -219,7 +219,7 @@ class IdConsistencyTest {
         
         assertNotNull("Session attributes must contain session.id", sessionId)
         assertTrue("Session ID in attributes must match format", 
-            sessionId!!.matches(Regex("""\d{13}_[a-z0-9]{8}""")))
+            sessionId!!.matches(Regex("""(device|user|session)_\d+_[0-9a-f]{16}_android""")))
     }
 
     @Test
@@ -364,7 +364,7 @@ class IdConsistencyTest {
         assertNotNull("Device ID must be generated", deviceId)
         assertNotNull("User ID must be generated", userId)
         
-        val idPattern = Regex("""\d{13}_[a-z0-9]{8}""")
+        val idPattern = Regex("""(device|user|session)_\d+_[0-9a-f]{16}_android""")
         assertTrue("All IDs must come from IdGenerator format", idPattern.matches(sessionId))
         assertTrue("All IDs must come from IdGenerator format", deviceId?.let { idPattern.matches(it) } ?: false)
         assertTrue("All IDs must come from IdGenerator format", idPattern.matches(userId))
@@ -376,7 +376,7 @@ class IdConsistencyTest {
         val userId = idGenerator.getUserId()
         val deviceId = idGenerator.getOrGenerateDeviceId()
         
-        val idPattern = Regex("""\d{13}_[a-z0-9]{8}""")
+        val idPattern = Regex("""(device|user|session)_\d+_[0-9a-f]{16}_android""")
         
         assertTrue("Session ID from IdGenerator must match format", idPattern.matches(sessionId))
         assertTrue("User ID from IdGenerator must match format", idPattern.matches(userId))

--- a/telemetry_library/src/test/java/com/androidtel/telemetry_library/core/ids/IdGeneratorTest.kt
+++ b/telemetry_library/src/test/java/com/androidtel/telemetry_library/core/ids/IdGeneratorTest.kt
@@ -24,7 +24,7 @@ class IdGeneratorTest {
     private lateinit var mockPrefs: SharedPreferences
     private lateinit var mockEditor: SharedPreferences.Editor
 
-    private val idFormatRegex = Regex("""^\d{13}_[a-z0-9]{8}$""")
+    private val idFormatRegex = Regex("""^(device|user|session)_\d+_[0-9a-f]{16}_android$""")
 
     @Before
     fun setup() {
@@ -86,18 +86,18 @@ class IdGeneratorTest {
     @Test
     fun `timestamp is 13 digits`() {
         val id = idGenerator.generateSessionId()
-        val timestamp = id.split("_")[0]
+        val timestamp = id.split("_")[1]
         assertEquals("Timestamp must be 13 digits", 13, timestamp.length)
         assertTrue("Timestamp must be numeric", timestamp.all { it.isDigit() })
     }
 
     @Test
-    fun `random string is 8 characters lowercase alphanumeric`() {
+    fun `random part is 16 lowercase hex characters`() {
         val id = idGenerator.generateSessionId()
-        val randomPart = id.split("_")[1]
-        assertEquals("Random part must be 8 characters", 8, randomPart.length)
-        assertTrue("Random part must be lowercase alphanumeric", 
-            randomPart.all { it in 'a'..'z' || it in '0'..'9' })
+        val randomPart = id.split("_")[2]
+        assertEquals("Random part must be 16 characters", 16, randomPart.length)
+        assertTrue("Random part must be lowercase hex",
+            randomPart.all { it in '0'..'9' || it in 'a'..'f' })
     }
 
     @Test
@@ -352,7 +352,7 @@ class IdGeneratorTest {
     // Test removed - clearUserId() method no longer exists
 
     @Test
-    fun `no prefix in generated IDs`() {
+    fun `kind prefix present per ID type`() {
         `when`(mockPrefs.getString("device_id", null)).thenReturn(null)
         `when`(mockPrefs.getString("edge_rum_user_id", null)).thenReturn(null)
 
@@ -360,13 +360,13 @@ class IdGeneratorTest {
         val userId = idGenerator.getUserId()
         val deviceId = idGenerator.getOrGenerateDeviceId()
 
-        assertFalse("Session ID must not have prefix", sessionId.contains("session"))
-        assertFalse("User ID must not have prefix", userId.contains("user"))
-        assertFalse("Device ID must not have prefix", deviceId.contains("device"))
+        assertTrue("Session ID must start with session_", sessionId.startsWith("session_"))
+        assertTrue("User ID must start with user_", userId.startsWith("user_"))
+        assertTrue("Device ID must start with device_", deviceId.startsWith("device_"))
     }
 
     @Test
-    fun `no suffix in generated IDs`() {
+    fun `android platform suffix present`() {
         `when`(mockPrefs.getString("device_id", null)).thenReturn(null)
         `when`(mockPrefs.getString("edge_rum_user_id", null)).thenReturn(null)
 
@@ -374,26 +374,28 @@ class IdGeneratorTest {
         val userId = idGenerator.getUserId()
         val deviceId = idGenerator.getOrGenerateDeviceId()
 
-        assertFalse("Session ID must not have suffix", sessionId.contains("android"))
-        assertFalse("User ID must not have suffix", userId.contains("android"))
-        assertFalse("Device ID must not have suffix", deviceId.contains("android"))
+        assertTrue("Session ID must end with _android", sessionId.endsWith("_android"))
+        assertTrue("User ID must end with _android", userId.endsWith("_android"))
+        assertTrue("Device ID must end with _android", deviceId.endsWith("_android"))
     }
 
     @Test
-    fun `ID contains exactly one underscore`() {
+    fun `ID contains exactly three underscores`() {
         val id = idGenerator.generateSessionId()
         val underscoreCount = id.count { it == '_' }
-        assertEquals("ID must contain exactly one underscore", 1, underscoreCount)
+        assertEquals("ID must contain exactly three underscores", 3, underscoreCount)
     }
 
     @Test
-    fun `ID parts are in correct order - timestamp first, random second`() {
+    fun `ID parts are in correct order - kind timestamp hex platform`() {
         val id = idGenerator.generateSessionId()
         val parts = id.split("_")
-        
-        assertEquals("ID must have exactly 2 parts", 2, parts.size)
-        assertTrue("First part must be numeric timestamp", parts[0].all { it.isDigit() })
-        assertTrue("Second part must be alphanumeric", parts[1].all { it in 'a'..'z' || it in '0'..'9' })
+
+        assertEquals("ID must have exactly 4 parts", 4, parts.size)
+        assertEquals("First part must be kind", "session", parts[0])
+        assertTrue("Second part must be numeric timestamp", parts[1].all { it.isDigit() })
+        assertTrue("Third part must be lowercase hex", parts[2].all { it in '0'..'9' || it in 'a'..'f' })
+        assertEquals("Fourth part must be platform", "android", parts[3])
     }
 
     @Test
@@ -402,8 +404,8 @@ class IdGeneratorTest {
         val id = idGenerator.generateSessionId()
         val afterGeneration = System.currentTimeMillis()
         
-        val timestamp = id.split("_")[0].toLong()
-        
+        val timestamp = id.split("_")[1].toLong()
+
         assertTrue("Timestamp must be >= time before generation", timestamp >= beforeGeneration)
         assertTrue("Timestamp must be <= time after generation", timestamp <= afterGeneration)
         
@@ -419,7 +421,7 @@ class IdGeneratorTest {
             Thread.sleep(1) // Small delay to ensure different timestamps
         }
         
-        val timestamps = ids.map { it.split("_")[0].toLong() }
+        val timestamps = ids.map { it.split("_")[1].toLong() }
         
         for (i in 1 until timestamps.size) {
             assertTrue(
@@ -567,9 +569,44 @@ class IdGeneratorTest {
         
         (sessionIds + listOf(userId) + deviceIds).forEach { id ->
             assertTrue(
-                "ID must match pattern \\d{13}_[a-z0-9]{8}: $id",
+                "ID must match pattern <kind>_<epochMs>_<16hex>_android: $id",
                 idFormatRegex.matches(id)
             )
         }
+    }
+
+    // --- Migration (#52): preserve persisted legacy IDs, new format only for newly-minted ---
+
+    @Test
+    fun `upgraded install - legacy device and user IDs preserved verbatim`() {
+        val legacyDeviceId = "1736899200000_a3k9zq1m"
+        val legacyUserId = "1736899200000_b7x2mq4p"
+        `when`(mockPrefs.getString("device_id", null)).thenReturn(legacyDeviceId)
+        `when`(mockPrefs.getString("edge_rum_user_id", null)).thenReturn(legacyUserId)
+
+        assertEquals("Legacy device ID must be returned unchanged", legacyDeviceId, idGenerator.getDeviceId())
+        assertEquals("Legacy user ID must be returned unchanged", legacyUserId, idGenerator.getUserId())
+        verify(mockEditor, never()).putString(eq("device_id"), anyString())
+        verify(mockEditor, never()).putString(eq("edge_rum_user_id"), anyString())
+    }
+
+    @Test
+    fun `upgraded install - session ID is still new format`() {
+        // Sessions are never persisted, so an upgraded install still mints new-format session IDs.
+        `when`(mockPrefs.getString("device_id", null)).thenReturn("1736899200000_a3k9zq1m")
+
+        val sessionId = idGenerator.generateSessionId()
+        assertTrue("Session ID must be new format: $sessionId", idFormatRegex.matches(sessionId))
+        assertTrue("Session ID must start with session_", sessionId.startsWith("session_"))
+    }
+
+    @Test
+    fun `fresh install - device user session all mint new format`() {
+        `when`(mockPrefs.getString("device_id", null)).thenReturn(null)
+        `when`(mockPrefs.getString("edge_rum_user_id", null)).thenReturn(null)
+
+        assertTrue(idGenerator.getOrGenerateDeviceId().matches(Regex("""^device_\d+_[0-9a-f]{16}_android$""")))
+        assertTrue(idGenerator.getUserId().matches(Regex("""^user_\d+_[0-9a-f]{16}_android$""")))
+        assertTrue(idGenerator.generateSessionId().matches(Regex("""^session_\d+_[0-9a-f]{16}_android$""")))
     }
 }


### PR DESCRIPTION
Closes #52.

## What
Newly-minted device/user/session IDs use the D7 self-describing format
`<kind>_<epochMs>_<16hex>_android`. Persisted device/user IDs are returned
**verbatim** on upgrade — never regenerated. IDs are opaque wire strings, so
rewriting a persisted `device_id`/`edge_rum_user_id` would fork every existing
install into a phantom "new device" for zero wire benefit. Only the mint branch
yields the new shape; sessions (never persisted) are always new-format.

One-file change plus test updates.

## Changes
- `IdGenerator.generateId()` → `generateId(kind)` = `"${kind}_${now}_${hex16()}_android"`
- add `hex16()` — 16 lowercase hex chars (64 bits) from the existing `SecureRandom`
- delete `CHARS`, `RANDOM_LENGTH`, `generateRandomString`
- callers pass their kind: `device` / `session` / `user`
- get-or-create logic untouched (persisted values still returned as-is)

No consumer changes — `DeviceInfoCollector`, `SessionService`, etc. all treat the ID as an opaque string.

## Acceptance criteria
- [x] New IDs match `<kind>_<epochMs>_<16hex>_android`
- [x] Persisted device/user IDs preserved verbatim on upgrade
- [x] Only newly-minted IDs use the new format

## Tests
Full unit suite green. Updated old-format regexes across `IdGeneratorTest`,
`IdConsistencyTest`, `TelemetryIdValidationTest`; added fresh-install /
upgrade-preserved / session-always-new migration tests.