### PR TITLE
feat(#54): windowed frame.summary replaces per-frame frame_drop firehose

### DIFF
--- a/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/TelemetryFrameDropCollector.kt
+++ b/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/TelemetryFrameDropCollector.kt
@@ -2,114 +2,209 @@ package com.androidtel.telemetry_library.core
 
 import android.app.Activity
 import android.os.Build
+import android.os.SystemClock
 import android.util.Log
 import android.view.FrameMetrics
 import android.view.Window
+import com.androidtel.telemetry_library.core.navigation.NavigationStackTracker
 import java.lang.ref.WeakReference
 
 /**
- * Frame drop collector with runtime capability detection.
+ * Windowed frame-metric collector (issue #54).
+ *
+ * Replaces the retired per-frame `frame_drop` firehose with at most one `frame.summary` per
+ * screen-segment (≤10s), emitted only when the window contained slow frames. All aggregation is
+ * O(1)-memory counters updated inside the frame callback — no timer, no external wiring.
+ *
+ * A window closes on whichever comes first: the current screen differs from the one captured at
+ * window start, or 10s elapse. Thresholds are fixed, Android-Vitals-aligned (slow >16ms,
+ * frozen >700ms); the device refresh rate is recorded, not used to move the threshold.
+ *
  * Only functions on devices with API 24+ (Android N) that support FrameMetrics.
  */
 class TelemetryFrameDropCollector(
-    private val telemetryManager: TelemetryManager = TelemetryManager.getInstance()
+    private val telemetryManager: TelemetryManager = TelemetryManager.getInstance(),
+    // Seams for unit testing (spec §Test plan). Production leaves these null and reads the real
+    // clock / the current activity.
+    private val clock: () -> Long = { SystemClock.elapsedRealtime() },
+    private val screenOverride: (() -> String?)? = null,
+    private val refreshRateOverride: (() -> Float)? = null,
 ) {
     // Store listener reference to enable removal
     private var frameMetricsListener: Window.OnFrameMetricsAvailableListener? = null
-    
+
     // Store current activity reference to track state (using WeakReference to prevent memory leaks)
     private var currentActivityRef: WeakReference<Activity>? = null
-    
+
+    // Window aggregator — guarded by @Synchronized (frame callback thread vs. stop() on main thread).
+    private var windowOpen = false
+    private var windowStart = 0L
+    private var windowScreen: String? = null
+    private var windowRefreshRate = 0f
+    private var totalFrames = 0
+    private var slowFrames = 0
+    private var frozenFrames = 0
+    private var maxTotalMs = 0.0
+    private var maxBuildMs = 0.0
+    private var maxRasterMs = 0.0
+
     @Synchronized
     fun start(activity: Activity) {
         // Prevent duplicate listeners - stop existing listener first
         if (frameMetricsListener != null) {
             stop()
         }
-        
+
         // Check if activity window is available
         val window = activity.window
         if (window == null) {
-            Log.w("TelemetryFrameDropCollector", "Activity window is null, cannot add frame metrics listener")
+            Log.w(TAG, "Activity window is null, cannot add frame metrics listener")
             return
         }
-        
+
         // Create and store the listener (only if frame metrics are supported)
         try {
             frameMetricsListener = Window.OnFrameMetricsAvailableListener { _, metrics, _ ->
                 try {
-                    val totalDurationNs = metrics.getMetric(FrameMetrics.TOTAL_DURATION)
-                    val drawDurationNs = metrics.getMetric(FrameMetrics.DRAW_DURATION)
-                    val layoutMeasureNs = metrics.getMetric(FrameMetrics.LAYOUT_MEASURE_DURATION)
-
-                    val totalMs = totalDurationNs / 1_000_000.0
-                    val buildMs = layoutMeasureNs / 1_000_000.0
-                    val rasterMs = drawDurationNs / 1_000_000.0
-
-                    val targetFps = 60
-                    val budgetMs = 1000.0 / targetFps
-                    val severity = when {
-                        totalMs > budgetMs * 3 -> "high"
-                        totalMs > budgetMs * 2 -> "medium"
-                        else -> "low"
-                    }
-
-                    // Only record if frame tracking is enabled
-                    if (telemetryManager.isFrameTrackingEnabled()) {
-                        telemetryManager.recordEvent(
-                            eventName = "frame_drop",
-                            attributes = mapOf(
-                                "frame.build_duration_ms" to buildMs,
-                                "frame.raster_duration_ms" to rasterMs,
-                                "frame.total_duration_ms" to totalMs,
-                                "frame.severity" to severity,
-                                "frame.target_fps" to targetFps
-                            )
-                        )
-                    }
+                    val totalMs = metrics.getMetric(FrameMetrics.TOTAL_DURATION) / 1_000_000.0
+                    val buildMs = metrics.getMetric(FrameMetrics.LAYOUT_MEASURE_DURATION) / 1_000_000.0
+                    val rasterMs = metrics.getMetric(FrameMetrics.DRAW_DURATION) / 1_000_000.0
+                    onFrame(totalMs, buildMs, rasterMs)
                 } catch (e: Exception) {
-                    Log.w("TelemetryFrameDropCollector", "Error processing frame metrics: ${e.localizedMessage}")
+                    Log.w(TAG, "Error processing frame metrics: ${e.localizedMessage}")
                 }
             }
         } catch (e: Exception) {
-            Log.w("TelemetryFrameDropCollector", "Failed to create frame metrics listener: ${e.localizedMessage}")
+            Log.w(TAG, "Failed to create frame metrics listener: ${e.localizedMessage}")
             return
         }
-        
+
+        // Store activity reference before adding the listener so the first frame can attribute a screen
+        currentActivityRef = WeakReference(activity)
+
         // Add listener to window
         frameMetricsListener?.let { listener ->
             window.addOnFrameMetricsAvailableListener(listener, null)
         }
-        
-        // Store activity reference
-        currentActivityRef = WeakReference(activity)
-        
-        Log.d("TelemetryFrameDropCollector", "Frame metrics listener started for ${activity.javaClass.simpleName}")
+
+        Log.d(TAG, "Frame metrics listener started for ${activity.javaClass.simpleName}")
     }
-    
+
+    /**
+     * Internal seam: accumulate one frame and close the window on a screen change or the 10s cap.
+     * The real FrameMetrics listener calls this; unit tests feed synthetic frames directly.
+     */
+    @Synchronized
+    internal fun onFrame(totalMs: Double, buildMs: Double, rasterMs: Double) {
+        if (!telemetryManager.isFrameTrackingEnabled()) return
+
+        if (!windowOpen) openWindow()
+
+        totalFrames++
+        if (totalMs > SLOW_THRESHOLD_MS) slowFrames++
+        if (totalMs > FROZEN_THRESHOLD_MS) frozenFrames++
+        if (totalMs > maxTotalMs) maxTotalMs = totalMs
+        if (buildMs > maxBuildMs) maxBuildMs = buildMs
+        if (rasterMs > maxRasterMs) maxRasterMs = rasterMs
+
+        if (currentScreen() != windowScreen || clock() - windowStart >= WINDOW_CAP_MS) {
+            flushWindow()
+        }
+    }
+
+    private fun openWindow() {
+        windowOpen = true
+        windowStart = clock()
+        windowScreen = currentScreen()
+        windowRefreshRate = currentRefreshRate()
+        totalFrames = 0
+        slowFrames = 0
+        frozenFrames = 0
+        maxTotalMs = 0.0
+        maxBuildMs = 0.0
+        maxRasterMs = 0.0
+    }
+
+    private fun flushWindow() {
+        if (!windowOpen) return
+        if (slowFrames > 0 && telemetryManager.isFrameTrackingEnabled()) {
+            telemetryManager.recordEvent(
+                eventName = "frame.summary",
+                attributes = mapOf(
+                    "frame.total_frames" to totalFrames,
+                    "frame.slow_frames" to slowFrames,
+                    "frame.frozen_frames" to frozenFrames,
+                    "frame.slow_frame_rate" to slowFrames.toDouble() / totalFrames,
+                    "frame.max_total_duration_ms" to maxTotalMs,
+                    "frame.max_build_duration_ms" to maxBuildMs,
+                    "frame.max_raster_duration_ms" to maxRasterMs,
+                    "frame.window_duration_ms" to (clock() - windowStart).toDouble(),
+                    "display.refresh_rate" to windowRefreshRate,
+                    "screen.name" to (windowScreen ?: "")
+                )
+            )
+        }
+        windowOpen = false
+    }
+
+    // Production screen source is the process-wide NavigationStackTracker latch (spec §1) so the
+    // window segments on real navigation across both Activity and single-Activity Compose apps. Falls
+    // back to the activity name only before the first navigation event has been recorded.
+    private fun currentScreen(): String? =
+        screenOverride?.invoke()
+            ?: NavigationStackTracker.currentScreen()
+            ?: currentActivityRef?.get()?.let { screenNameOf(it) }
+
+    private fun currentRefreshRate(): Float =
+        refreshRateOverride?.invoke() ?: (currentActivityRef?.get()?.let { refreshRateOf(it) } ?: 0f)
+
+    private fun screenNameOf(activity: Activity): String =
+        if (activity.title?.isNotEmpty() == true) activity.title.toString() else activity.javaClass.simpleName
+
+    private fun refreshRateOf(activity: Activity): Float = try {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            activity.display?.refreshRate ?: 0f
+        } else {
+            @Suppress("DEPRECATION")
+            activity.windowManager.defaultDisplay.refreshRate
+        }
+    } catch (e: Exception) {
+        0f
+    }
+
     @Synchronized
     fun stop() {
+        // Flush the trailing partial window before tearing down.
+        flushWindow()
+
         val listener = frameMetricsListener
         val activity = currentActivityRef?.get()
-        
+
         if (listener != null && activity != null) {
             try {
                 activity.window?.removeOnFrameMetricsAvailableListener(listener)
-                Log.d("TelemetryFrameDropCollector", "Frame metrics listener removed for ${activity.javaClass.simpleName}")
+                Log.d(TAG, "Frame metrics listener removed for ${activity.javaClass.simpleName}")
             } catch (e: Exception) {
-                Log.w("TelemetryFrameDropCollector", "Failed to remove frame metrics listener: ${e.localizedMessage}")
+                Log.w(TAG, "Failed to remove frame metrics listener: ${e.localizedMessage}")
             }
         }
-        
+
         // Clear references to prevent memory leaks
         frameMetricsListener = null
         currentActivityRef = null
     }
-    
+
     /**
      * Check if collector is currently active
      */
     fun isActive(): Boolean {
         return frameMetricsListener != null && currentActivityRef?.get() != null
+    }
+
+    private companion object {
+        const val TAG = "TelemetryFrameDropCollector"
+        const val SLOW_THRESHOLD_MS = 16.0
+        const val FROZEN_THRESHOLD_MS = 700.0
+        const val WINDOW_CAP_MS = 10_000L
     }
 }

--- a/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/navigation/NavigationStackTracker.kt
+++ b/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/navigation/NavigationStackTracker.kt
@@ -14,6 +14,7 @@ class NavigationStackTracker {
         return lock.write {
             val fromScreen = navigationStack.peekLast()
             navigationStack.addLast(screenName)
+            sharedCurrentScreen = screenName
             NavigationEvent(
                 fromScreen = fromScreen,
                 toScreen = screenName,
@@ -28,6 +29,7 @@ class NavigationStackTracker {
             if (navigationStack.size < 2) return null
             val fromScreen = navigationStack.removeLast()
             val toScreen = navigationStack.peekLast() ?: return null
+            sharedCurrentScreen = toScreen
             NavigationEvent(
                 fromScreen = fromScreen,
                 toScreen = toScreen,
@@ -43,6 +45,7 @@ class NavigationStackTracker {
                 navigationStack.removeLast()
             } else null
             navigationStack.addLast(screenName)
+            sharedCurrentScreen = screenName
             NavigationEvent(
                 fromScreen = fromScreen,
                 toScreen = screenName,
@@ -54,8 +57,19 @@ class NavigationStackTracker {
     
     fun getCurrentScreen(): String? = lock.read { navigationStack.peekLast() }
     
-    fun getPreviousScreen(): String? = lock.read { 
+    fun getPreviousScreen(): String? = lock.read {
         if (navigationStack.size >= 2) navigationStack.elementAt(navigationStack.size - 2) else null
+    }
+
+    companion object {
+        // Process-wide latch of the most recently navigated screen, updated by every
+        // push/pop/replace on any tracker instance. Lets components without their own tracker
+        // (e.g. the frame collector, #54) read the current screen across both Activity and
+        // single-Activity Compose navigation.
+        @Volatile
+        private var sharedCurrentScreen: String? = null
+
+        fun currentScreen(): String? = sharedCurrentScreen
     }
 }
 

--- a/telemetry_library/src/test/java/com/androidtel/telemetry_library/core/TelemetryFrameDropCollectorTest.kt
+++ b/telemetry_library/src/test/java/com/androidtel/telemetry_library/core/TelemetryFrameDropCollectorTest.kt
@@ -1,0 +1,118 @@
+package com.androidtel.telemetry_library.core
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Issue #54: windowed `frame.summary` replaces the per-frame `frame_drop` firehose.
+ * Frames are fed through the internal `onFrame(totalMs, buildMs, rasterMs)` seam; screen and clock
+ * are injected so window boundaries (screen-change, 10s cap) can be forced deterministically.
+ */
+class TelemetryFrameDropCollectorTest {
+
+    private var screen: String? = "A"
+    private var clockMs = 0L
+    private val captured = mutableListOf<Map<String, Any>>()
+
+    private fun newCollector(): TelemetryFrameDropCollector {
+        captured.clear()
+        val manager = mockk<TelemetryManager>(relaxed = true)
+        every { manager.isFrameTrackingEnabled() } returns true
+        every { manager.recordEvent(eq("frame.summary"), capture(captured)) } returns Unit
+        return TelemetryFrameDropCollector(
+            telemetryManager = manager,
+            clock = { clockMs },
+            screenOverride = { screen },
+            refreshRateOverride = { 90f },
+        )
+    }
+
+    @Test
+    fun `counts, rate and maxes match golden payload`() {
+        screen = "Home"; clockMs = 0
+        val c = newCollector()
+        // 3 smooth (<=16ms)
+        repeat(3) { c.onFrame(totalMs = 10.0, buildMs = 2.0, rasterMs = 3.0) }
+        // 2 slow (16 < ms <= 700)
+        c.onFrame(totalMs = 20.0, buildMs = 5.0, rasterMs = 8.0)
+        c.onFrame(totalMs = 30.0, buildMs = 7.0, rasterMs = 10.0)
+        // 1 frozen (> 700)
+        c.onFrame(totalMs = 800.0, buildMs = 12.0, rasterMs = 40.0)
+        c.stop() // forces trailing flush
+
+        assertEquals(1, captured.size)
+        val a = captured.single()
+        assertEquals(6, a["frame.total_frames"])
+        assertEquals(3, a["frame.slow_frames"])          // 2 slow + 1 frozen
+        assertEquals(1, a["frame.frozen_frames"])
+        assertEquals(0.5, a["frame.slow_frame_rate"])    // 3/6
+        assertEquals(800.0, a["frame.max_total_duration_ms"])
+        assertEquals(12.0, a["frame.max_build_duration_ms"])
+        assertEquals(40.0, a["frame.max_raster_duration_ms"])
+        assertEquals(90f, a["display.refresh_rate"])
+        assertEquals("Home", a["screen.name"])
+    }
+
+    @Test
+    fun `smooth-only window emits nothing`() {
+        screen = "A"; clockMs = 0
+        val c = newCollector()
+        repeat(10) { c.onFrame(totalMs = 8.0, buildMs = 1.0, rasterMs = 2.0) }
+        c.stop()
+        assertEquals(0, captured.size)
+    }
+
+    @Test
+    fun `screen change splits into two summaries`() {
+        screen = "A"; clockMs = 0
+        val c = newCollector()
+        c.onFrame(totalMs = 20.0, buildMs = 3.0, rasterMs = 4.0)
+        c.onFrame(totalMs = 25.0, buildMs = 3.0, rasterMs = 4.0)
+        screen = "B"
+        c.onFrame(totalMs = 30.0, buildMs = 3.0, rasterMs = 4.0) // boundary frame -> counts in A, flushes A
+        c.onFrame(totalMs = 40.0, buildMs = 3.0, rasterMs = 4.0) // opens & fills B
+        c.stop()
+
+        assertEquals(2, captured.size)
+        assertEquals("A", captured[0]["screen.name"])
+        assertEquals(3, captured[0]["frame.slow_frames"])
+        assertEquals("B", captured[1]["screen.name"])
+        assertEquals(1, captured[1]["frame.slow_frames"])
+    }
+
+    @Test
+    fun `10s cap flushes and opens a fresh window`() {
+        screen = "A"; clockMs = 1000
+        val c = newCollector()
+        c.onFrame(totalMs = 20.0, buildMs = 3.0, rasterMs = 4.0) // window starts at 1000
+        clockMs = 2000
+        c.onFrame(totalMs = 25.0, buildMs = 3.0, rasterMs = 4.0)
+        clockMs = 12000 // >= 10s since start -> boundary frame flushes window 1
+        c.onFrame(totalMs = 30.0, buildMs = 3.0, rasterMs = 4.0)
+        c.onFrame(totalMs = 40.0, buildMs = 3.0, rasterMs = 4.0) // fresh window 2
+        c.stop()
+
+        assertEquals(2, captured.size)
+        assertEquals(3, captured[0]["frame.slow_frames"]) // window 1
+        assertEquals(1, captured[1]["frame.slow_frames"]) // window 2
+    }
+
+    @Test
+    fun `retired frame_drop event is never emitted`() {
+        screen = "A"; clockMs = 0
+        val manager = mockk<TelemetryManager>(relaxed = true)
+        every { manager.isFrameTrackingEnabled() } returns true
+        val c = TelemetryFrameDropCollector(
+            telemetryManager = manager,
+            clock = { clockMs },
+            screenOverride = { screen },
+            refreshRateOverride = { 90f },
+        )
+        c.onFrame(totalMs = 800.0, buildMs = 3.0, rasterMs = 4.0)
+        c.stop()
+        verify(exactly = 0) { manager.recordEvent(eq("frame_drop"), any()) }
+    }
+}

--- a/telemetry_library/src/test/java/com/androidtel/telemetry_library/navigation/NavigationStackTrackerTest.kt
+++ b/telemetry_library/src/test/java/com/androidtel/telemetry_library/navigation/NavigationStackTrackerTest.kt
@@ -143,6 +143,21 @@ class NavigationStackTrackerTest {
     }
     
     @Test
+    fun `shared currentScreen latch follows push and pop across instances`() {
+        // The process-wide latch (issue #54) is updated by any instance's push/pop/replace.
+        tracker.push("ScreenA")
+        tracker.push("ScreenB")
+        assertEquals("ScreenB", NavigationStackTracker.currentScreen())
+
+        tracker.pop()
+        assertEquals("ScreenA", NavigationStackTracker.currentScreen())
+
+        // A different instance's navigation also moves the shared latch.
+        NavigationStackTracker().push("ScreenC")
+        assertEquals("ScreenC", NavigationStackTracker.currentScreen())
+    }
+
+    @Test
     fun `multiple push and pop operations maintain stack integrity`() {
         tracker.push("ScreenA")
         tracker.push("ScreenB")


### PR DESCRIPTION
Closes #54.

Replaces the per-frame `frame_drop` firehose (~36k events/session) with a windowed `frame.summary`: at most one event per screen segment (≤10s), emitted only when the window contained slow frames.

## What changed
- **`TelemetryFrameDropCollector`** rewritten from per-frame emit → accumulate-and-flush. O(1) counters/maxes updated inside the frame callback; no timer, no external wiring.
  - Fixed Vitals-aligned thresholds: slow >16ms, frozen >700ms.
  - `display.refresh_rate` recorded at window start (recorded, not used to move the threshold).
  - Window closes on **screen change** or the **10s cap**, checked in-callback after counters update; trailing window flushed on `stop()`.
  - Retired `frame_drop` + its `target_fps`/`severity` tiers. No sampling, no percentiles.
  - Internal `onFrame(totalMs, buildMs, rasterMs)` seam + injectable clock/screen/refresh-rate seams for deterministic tests.
- **`NavigationStackTracker`** gains a process-wide `currentScreen()` latch (updated by every push/pop/replace) so the collector reads real navigation across Activity **and** single-Activity Compose apps — the spec's single screen source.

## Event shape (`frame.summary`)
`frame.total_frames`, `frame.slow_frames`, `frame.frozen_frames`, `frame.slow_frame_rate`, `frame.max_total_duration_ms`, `frame.max_build_duration_ms`, `frame.max_raster_duration_ms`, `frame.window_duration_ms`, `display.refresh_rate`, `screen.name`.

## Tests
- `TelemetryFrameDropCollectorTest` — golden counts/maxes, no-emit floor, screen-change split, 10s cap, `frame_drop` retired.
- `NavigationStackTrackerTest` — shared `currentScreen()` latch follows push/pop across instances.
- Full unit suite green.

## Notes
- `LegacyPerformanceTracker` stays dead (still references `frame_drop`); its removal is deferred to the #37 dead-code sweep per the spec.

Spec: `docs/specs/frame-metrics-windowing.md`