### PR TITLE
feat(#57): unify network schema + URL sanitization — one http.request event

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,6 @@ edge_telemetry_android/
 │           ├── user/                     # UserProfileManager
 │           ├── ids/                      # IdGenerator (device, session, user IDs)
 │           ├── navigation/              # NavigationStackTracker
-│           ├── http/                     # EdgeTelemetryInterceptor
 │           ├── device/                   # DeviceInfoCollector
 │           ├── location/                # IpLocationProvider (opt-in)
 │           ├── events/                  # JsonEventTracker

--- a/USAGE_EXAMPLE.kt
+++ b/USAGE_EXAMPLE.kt
@@ -379,11 +379,7 @@ fun MyAppTheme(content: @Composable () -> Unit) {
 /*
 class ApiService {
     private val httpClient = OkHttpClient.Builder()
-        .addInterceptor(EdgeTelemetryInterceptor(
-            eventTracker = EdgeTelemetry.getInstance().eventTracker,
-            breadcrumbManager = EdgeTelemetry.getInstance().breadcrumbManager,
-            telemetryEndpoint = "https://edgetelemetry.ncgafrica.com/collector/telemetry"
-        ))
+        .addInterceptor(TelemetryManager.createNetworkInterceptor())
         .build()
     
     suspend fun fetchUserData(): Result<UserData> {

--- a/telemetry_library/api/current.api
+++ b/telemetry_library/api/current.api
@@ -324,7 +324,6 @@ package com.androidtel.telemetry_library.core {
     method @Deprecated public void recordError(Throwable throwable, optional java.util.Map<java.lang.String,?> attributes);
     method public void recordEvent(String eventName, optional java.util.Map<java.lang.String,?> attributes);
     method public void recordMetric(String metricName, double value, optional java.util.Map<java.lang.String,?> attributes);
-    method public void recordNetworkRequest(String url, String method, int statusCode, long durationMs, optional long requestBodySize, optional long responseBodySize, optional String? error, optional java.util.Map<java.lang.String,?> attributes);
     method public void recordScreenDuration(String screenName, long durationMs, String exitMethod);
     method @Deprecated public void recordScreenView(String screenName);
     method public void setLastUserAction(String action);
@@ -495,19 +494,6 @@ package com.androidtel.telemetry_library.core.events {
   }
 
   public static final class JsonEventTracker.Companion {
-  }
-
-}
-
-package com.androidtel.telemetry_library.core.http {
-
-  public final class EdgeTelemetryInterceptor implements okhttp3.Interceptor {
-    ctor public EdgeTelemetryInterceptor(com.androidtel.telemetry_library.core.events.JsonEventTracker eventTracker, com.androidtel.telemetry_library.core.breadcrumbs.BreadcrumbManager breadcrumbManager, String telemetryEndpoint);
-    method public okhttp3.Response intercept(okhttp3.Interceptor.Chain chain);
-    field public static final com.androidtel.telemetry_library.core.http.EdgeTelemetryInterceptor.Companion Companion;
-  }
-
-  public static final class EdgeTelemetryInterceptor.Companion {
   }
 
 }

--- a/telemetry_library/consumer-rules.pro
+++ b/telemetry_library/consumer-rules.pro
@@ -22,17 +22,11 @@
     public *** trackScreen(...);
     public *** setUserProfile(...);
     public *** clearUserProfile(...);
-    public *** recordNetworkRequest(...);
     public static *** createNetworkInterceptor();
 }
 
 # Keep TelemetryInterceptor for OkHttp integration
 -keep public class com.androidtel.telemetry_library.core.TelemetryInterceptor {
-    public <init>(...);
-}
-
-# Keep EdgeTelemetryInterceptor for OkHttp integration
--keep public class com.androidtel.telemetry_library.core.http.EdgeTelemetryInterceptor {
     public <init>(...);
 }
 

--- a/telemetry_library/src/androidTest/java/com/androidtel/telemetry_library/EventIntegrationTest.kt
+++ b/telemetry_library/src/androidTest/java/com/androidtel/telemetry_library/EventIntegrationTest.kt
@@ -12,8 +12,6 @@ import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
 
 /**
  * End-to-End Integration Tests
@@ -51,19 +49,6 @@ class EventIntegrationTest {
     
     @Test
     fun testHttpRequestEventTracking() {
-        val latch = CountDownLatch(1)
-        
-        // Track HTTP request
-        telemetryManager.recordNetworkRequest(
-            url = "https://api.example.com/users",
-            method = "GET",
-            statusCode = 200,
-            durationMs = 150L
-        )
-        
-        // Give time for event to be queued
-        latch.await(1, TimeUnit.SECONDS)
-        
         // Verify event would pass validation
         val attributes = mapOf(
             "http.url" to "https://api.example.com/users",

--- a/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/TelemetryInterceptor.kt
+++ b/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/TelemetryInterceptor.kt
@@ -2,7 +2,6 @@ package com.androidtel.telemetry_library.core
 
 import okhttp3.Interceptor
 import okhttp3.Response
-import java.io.IOException
 import java.util.concurrent.TimeUnit
 
 class TelemetryInterceptor(
@@ -21,32 +20,28 @@ class TelemetryInterceptor(
         
         val startTime = System.nanoTime()
         var response: Response? = null
-        var error: IOException? = null
 
         try {
             response = chain.proceed(request)
             return response
-        } catch (e: IOException) {
-            error = e
-            throw e
         } finally {
             val endTime = System.nanoTime()
             val durationMs = TimeUnit.NANOSECONDS.toMillis(endTime - startTime)
-            val requestBodySize = request.body?.contentLength() ?: 0
-            val responseBodySize = response?.body?.contentLength() ?: 0
             val statusCode = response?.code ?: 0
 
-            telemetryManager.recordEvent(
-                eventName = "http_request",
-                attributes = mapOf(
-                    "url" to requestUrl.substringBefore('?'),
-                    "method" to request.method,
-                    "response_code" to statusCode,
-                    "latency_ms" to durationMs,
-                    "request_size_bytes" to requestBodySize,
-                    "response_size_bytes" to responseBodySize
-                )
-            )
+            val attributes = buildMap<String, Any> {
+                put("http.url", requestUrl.substringBefore('?'))
+                put("http.method", request.method)
+                put("http.status_code", statusCode)
+                put("http.duration_ms", durationMs)
+                put("http.success", statusCode in 200..299)
+                // Omit size fields when contentLength() < 0 (chunked/streamed): a true
+                // "optional pair", so the backend column stays null rather than a false 0.
+                request.body?.contentLength()?.takeIf { it >= 0 }?.let { put("http.request_size", it) }
+                response?.body?.contentLength()?.takeIf { it >= 0 }?.let { put("http.response_size", it) }
+            }
+
+            telemetryManager.recordEvent(eventName = "http.request", attributes = attributes)
         }
     }
     

--- a/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/TelemetryManager.kt
+++ b/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/TelemetryManager.kt
@@ -518,36 +518,6 @@ class TelemetryManager private constructor(
     }
 
 
-
-    // --- Network Request Tracking ---
-    fun recordNetworkRequest(
-        url: String,
-        method: String,
-        statusCode: Int,
-        durationMs: Long,
-        requestBodySize: Long = 0,
-        responseBodySize: Long = 0,
-        error: String? = null,
-        attributes: Map<String, Any> = emptyMap()
-    ) {
-        if (!isReady.get()) {
-            offerToPreInitQueue { recordNetworkRequest(url, method, statusCode, durationMs, requestBodySize, responseBodySize, error, attributes) }
-            return
-        }
-        
-        val userInfo = userProfileService.getUserInfo()
-        val sessionInfo = sessionService.getSessionInfo(
-            eventTrackingService.getEventCount(),
-            eventTrackingService.getMetricCount(),
-            getNetworkType(context)
-        )
-        
-        eventTrackingService.recordNetworkRequest(
-            url, method, statusCode, durationMs, requestBodySize, responseBodySize, error, attributes, userInfo, sessionInfo
-        )
-        maybeSendBatch()
-    }
-
     // --- Crash and Error Reporting ---
     fun recordCrash(throwable: Throwable) {
         crashReportingService.recordCrash(throwable)

--- a/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/services/EventTrackingService.kt
+++ b/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/services/EventTrackingService.kt
@@ -93,36 +93,6 @@ internal class EventTrackingService(
     }
     
     /**
-     * Record network request event
-     */
-    fun recordNetworkRequest(
-        url: String,
-        method: String,
-        statusCode: Int,
-        durationMs: Long,
-        requestBodySize: Long = 0,
-        responseBodySize: Long = 0,
-        error: String? = null,
-        attributes: Map<String, Any> = emptyMap(),
-        userInfo: UserInfo,
-        sessionInfo: SessionInfo
-    ) {
-        val networkAttributes = mapOf(
-            "http.url" to url,
-            "http.method" to method,
-            "http.status_code" to statusCode,
-            "http.duration_ms" to durationMs,
-            "http.timestamp" to TelemetryTime.now(),
-            "http.success" to (statusCode < 400),
-            "http.request_body_size" to requestBodySize,
-            "http.response_body_size" to responseBodySize,
-            "http.error" to (error ?: "none")
-        )
-        val combinedAttributes = attributes + networkAttributes
-        recordEvent("http.request", combinedAttributes, userInfo, sessionInfo)
-    }
-    
-    /**
      * Build event attributes with full context
      */
     private fun buildAttributes(

--- a/telemetry_library/src/test/java/com/androidtel/telemetry_library/core/TelemetryInterceptorTest.kt
+++ b/telemetry_library/src/test/java/com/androidtel/telemetry_library/core/TelemetryInterceptorTest.kt
@@ -1,0 +1,71 @@
+package com.androidtel.telemetry_library.core
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.util.concurrent.TimeUnit
+
+class TelemetryInterceptorTest {
+
+    private lateinit var server: MockWebServer
+    private lateinit var client: OkHttpClient
+    private val telemetryManager: TelemetryManager = mockk(relaxed = true)
+    private val recorded = slot<Map<String, Any>>()
+
+    @Before
+    fun setup() {
+        server = MockWebServer()
+        server.start()
+        client = OkHttpClient.Builder()
+            .addInterceptor(TelemetryInterceptor(telemetryManager))
+            .connectTimeout(1, TimeUnit.SECONDS)
+            .readTimeout(1, TimeUnit.SECONDS)
+            .build()
+        every { telemetryManager.recordEvent("http.request", capture(recorded)) } returns Unit
+    }
+
+    @After
+    fun teardown() {
+        server.shutdown()
+        // Release non-daemon OkHttp threads so the suite doesn't hang (see takerequest gotcha).
+        client.dispatcher.executorService.shutdown()
+        client.connectionPool.evictAll()
+    }
+
+    @Test
+    fun `auto HTTP emits http dot keys, 2xx success, no query string`() {
+        server.enqueue(MockResponse().setResponseCode(200))
+        client.newCall(
+            Request.Builder().url(server.url("/pay?token=SECRET&acct=123")).build()
+        ).execute().close()
+
+        val a = recorded.captured
+        assertTrue("http.status_code present", a.containsKey("http.status_code"))
+        assertEquals(200, a["http.status_code"])
+        assertEquals(true, a["http.success"])
+        assertFalse("no query on the wire", (a["http.url"] as String).contains("?"))
+        assertFalse("no token leak", (a["http.url"] as String).contains("SECRET"))
+        assertFalse("no legacy http.error key", a.containsKey("http.error"))
+    }
+
+    @Test
+    fun `transport failure emits status 0, success false, still recorded`() {
+        // Point client at a dead port so chain.proceed throws IOException.
+        runCatching {
+            client.newCall(Request.Builder().url("http://127.0.0.1:1/x").build()).execute()
+        }
+        assertEquals(0, recorded.captured["http.status_code"])
+        assertEquals(false, recorded.captured["http.success"])
+        assertFalse(recorded.captured.containsKey("http.error"))
+    }
+}

--- a/telemetry_library/src/test/java/com/androidtel/telemetry_library/core/services/EventTrackingServiceTest.kt
+++ b/telemetry_library/src/test/java/com/androidtel/telemetry_library/core/services/EventTrackingServiceTest.kt
@@ -194,55 +194,6 @@ class EventTrackingServiceTest {
     }
 
     @Test
-    fun `test recordNetworkRequest creates event with network attributes`() {
-        service.recordNetworkRequest(
-            url = "https://api.example.com/users",
-            method = "POST",
-            statusCode = 200,
-            durationMs = 345,
-            requestBodySize = 1024,
-            responseBodySize = 2048,
-            error = null,
-            attributes = emptyMap(),
-            userInfo = userInfo,
-            sessionInfo = sessionInfo
-        )
-        
-        assertEquals(1, service.getEventCount())
-        val event = service.getEventQueue().peek()
-        assertEquals("http.request", event?.eventName)
-        
-        val customAttrs = event?.attributes?.customAttributes as Map<*, *>
-        assertEquals("https://api.example.com/users", customAttrs["http.url"])
-        assertEquals("POST", customAttrs["http.method"])
-        assertEquals(200, customAttrs["http.status_code"])
-        assertEquals(345L, customAttrs["http.duration_ms"])
-        assertEquals(true, customAttrs["http.success"])
-        assertEquals(1024L, customAttrs["http.request_body_size"])
-        assertEquals(2048L, customAttrs["http.response_body_size"])
-        assertEquals("none", customAttrs["http.error"])
-    }
-
-    @Test
-    fun `test recordNetworkRequest with error`() {
-        service.recordNetworkRequest(
-            url = "https://api.example.com/users",
-            method = "GET",
-            statusCode = 500,
-            durationMs = 123,
-            error = "Internal Server Error",
-            attributes = emptyMap(),
-            userInfo = userInfo,
-            sessionInfo = sessionInfo
-        )
-        
-        val event = service.getEventQueue().peek()
-        val customAttrs = event?.attributes?.customAttributes as Map<*, *>
-        assertEquals(false, customAttrs["http.success"])
-        assertEquals("Internal Server Error", customAttrs["http.error"])
-    }
-
-    @Test
     fun `test resetEventCount clears count`() {
         service.recordEvent("event1", emptyMap(), userInfo, sessionInfo)
         service.recordEvent("event2", emptyMap(), userInfo, sessionInfo)
@@ -371,24 +322,6 @@ class EventTrackingServiceTest {
         
         assertNull(event) // Should return null when appInfo is not initialized
         assertEquals(1, uninitializedService.getEventCount()) // Count still increments
-    }
-
-    @Test
-    fun `test network request with client error status code`() {
-        service.recordNetworkRequest(
-            url = "https://api.example.com/not-found",
-            method = "GET",
-            statusCode = 404,
-            durationMs = 100,
-            attributes = emptyMap(),
-            userInfo = userInfo,
-            sessionInfo = sessionInfo
-        )
-        
-        val event = service.getEventQueue().peek()
-        val customAttrs = event?.attributes?.customAttributes as Map<*, *>
-        assertEquals(false, customAttrs["http.success"])
-        assertEquals(404, customAttrs["http.status_code"])
     }
 
     @Test

--- a/telemetry_library/src/test/java/com/androidtel/telemetry_library/core/services/TelemetryManagerIntegrationTest.kt
+++ b/telemetry_library/src/test/java/com/androidtel/telemetry_library/core/services/TelemetryManagerIntegrationTest.kt
@@ -155,20 +155,6 @@ class TelemetryManagerIntegrationTest {
     }
 
     @Test
-    fun `test network tracking workflow`() {
-        telemetryManager.recordNetworkRequest(
-            url = "https://api.example.com/users",
-            method = "GET",
-            statusCode = 200,
-            durationMs = 234,
-            requestBodySize = 0,
-            responseBodySize = 1024
-        )
-
-        // Network request should be tracked
-    }
-
-    @Test
     fun `test breadcrumb workflow`() {
         telemetryManager.addBreadcrumb("Step 1", "navigation", "info")
         telemetryManager.addBreadcrumb("Step 2", "user_action", "debug")
@@ -360,14 +346,6 @@ class TelemetryManagerIntegrationTest {
         // Record events
         telemetryManager.recordEvent("login_attempt", mapOf("method" to "email"))
 
-        // Track network request
-        telemetryManager.recordNetworkRequest(
-            url = "https://api.example.com/auth/login",
-            method = "POST",
-            statusCode = 200,
-            durationMs = 456
-        )
-
         // Record success event
         telemetryManager.recordEvent("login_success", emptyMap())
 
@@ -407,19 +385,6 @@ class TelemetryManagerIntegrationTest {
         }
 
         // Batch should be triggered (verified by no exceptions)
-    }
-
-    @Test
-    fun `test network request with error tracking`() {
-        telemetryManager.recordNetworkRequest(
-            url = "https://api.example.com/error",
-            method = "GET",
-            statusCode = 500,
-            durationMs = 123,
-            error = "Internal Server Error"
-        )
-
-        // Error should be tracked
     }
 
     @Test


### PR DESCRIPTION
Closes #57.

Unifies all network capture onto a single `http.request` event with the D3 `http.*` key set the Processor reads. Previously the wired interceptor emitted `http_request` with `url`/`response_code`/… keys — dark server-side — while the `http.*` keys lived only on the rarely-used manual API.

## Changes
- **`TelemetryInterceptor.kt`** — one `http.request` event, re-keyed to `http.*`:
  - `url→http.url` (query stripped via `substringBefore('?')`), `method→http.method`, `response_code→http.status_code`, `latency_ms→http.duration_ms`, request/response size → `http.request_size`/`http.response_size`
  - add `http.success = code in 200..299` (D3a, 2xx-only — not `< 400`)
  - **omit** size fields when `contentLength() < 0` (chunked/streamed) — no false `0`
  - transport failure still emits `http.request` with `status_code=0`/`success=false`; **no `http.error`** field
  - interceptor does not set `http.timestamp` (owned by #41)
- **Delete the duplicate manual path** (D3): `TelemetryManager.recordNetworkRequest()` + its pre-init-queue branch, and `EventTrackingService.recordNetworkRequest()`, plus their tests and stale `api/current.api` / `consumer-rules.pro` / doc references. `EdgeTelemetryInterceptor` was already removed in #55.
- **New `TelemetryInterceptorTest`** — covers the `http.*` keys, query stripping, and the transport-failure edge (releases OkHttp threads in `@After`).

## Acceptance criteria
- [x] All network calls emit one `http.request` with D3 `http.*` keys
- [x] `http.success = code in 200..299`; query strings stripped by default
- [x] Transport failure → `status_code=0`/`success=false`; size fields omitted when `contentLength()<0`
- [x] Manual `recordNetworkRequest()` and unwired `EdgeTelemetryInterceptor` deleted

## Notes
- `EventPayloadValidator` still requires `http.timestamp` / rejects `status_code=0`. Left for **#41** — it's test-only (not in the runtime send path) and #41 owns the `http.timestamp` value/format.
- `api/current.api` was regenerated surgically (only the two removed symbols); the file was stale by several prior tickets and their drift was deliberately not swept in here.

## Testing
Full unit suite green (`./gradlew :telemetry_library:testDebugUnitTest`).