### PR TITLE
feat(#58): automatic ui.interaction capture with secure-surface suppression

### DIFF
--- a/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/TelemetryActivityLifecycleObserver.kt
+++ b/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/TelemetryActivityLifecycleObserver.kt
@@ -6,6 +6,7 @@ import android.os.Build
 import android.os.Bundle
 import android.util.Log
 import androidx.fragment.app.FragmentActivity
+import com.androidtel.telemetry_library.core.interaction.UserInteractionTracker
 import com.androidtel.telemetry_library.core.navigation.NavigationStackTracker
 
 class TelemetryActivityLifecycleObserver(
@@ -14,6 +15,7 @@ class TelemetryActivityLifecycleObserver(
 
     private val screenTimingTracker = ScreenTimingTracker()
     private val navigationTracker = NavigationStackTracker()
+    private val interactionTracker = UserInteractionTracker(telemetryManager, navigationTracker::getCurrentScreen)
     // Unified performance tracker - automatically selects appropriate implementation
     private val performanceTracker: PerformanceTracker = PerformanceTrackerFactory.createPerformanceTracker(telemetryManager)
 
@@ -43,6 +45,11 @@ class TelemetryActivityLifecycleObserver(
         // Start performance tracking (automatically uses appropriate implementation)
         performanceTracker.start(activity)
 
+        // Capture user interactions (taps/swipes) by wrapping the window callback
+        if (telemetryManager.isUserInteractionEventsEnabled()) {
+            interactionTracker.attach(activity)
+        }
+
         // Track navigation with proper structure
         val navEvent = navigationTracker.push(screenName)
         telemetryManager.recordEvent(
@@ -61,6 +68,9 @@ class TelemetryActivityLifecycleObserver(
     override fun onActivityPaused(activity: Activity) {
         val screenName = getScreenName(activity)
         Log.d("TelemetryObserver", "Activity Paused: $screenName")
+
+        // Restore the original window callback to avoid leaks / double-wrapping on re-resume
+        interactionTracker.detach(activity)
 
         // Stop performance tracking to prevent memory leaks. Do NOT end screen timing here:
         // onActivityStopped owns endScreen so screen.duration (with exit_method) fires on the

--- a/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/interaction/UserInteractionTracker.kt
+++ b/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/interaction/UserInteractionTracker.kt
@@ -1,0 +1,175 @@
+package com.androidtel.telemetry_library.core.interaction
+
+import android.app.Activity
+import android.text.InputType
+import android.view.GestureDetector
+import android.view.MotionEvent
+import android.view.View
+import android.view.ViewGroup
+import android.view.Window
+import android.view.WindowManager
+import android.widget.EditText
+import com.androidtel.telemetry_library.core.TelemetryManager
+import kotlin.math.abs
+
+/**
+ * Automatic user-interaction capture (issue #58 / spec `user-interaction-events.md`).
+ *
+ * One `ui.interaction` event per completed gesture, discriminated by `ui.type`
+ * (tap / long_press / swipe). Attaches by wrapping the Activity's [Window.Callback] on resume
+ * and restoring the original on pause. A [GestureDetector] collapses the raw MotionEvent stream
+ * into one callback per gesture; the touch point is hit-tested against the decorView to resolve
+ * a target, and capture is suppressed outright on secure surfaces (password field / FLAG_SECURE).
+ */
+class UserInteractionTracker(
+    private val telemetryManager: TelemetryManager,
+    private val currentScreen: () -> String?
+) {
+
+    /** Wrap the window callback so touches feed a per-window [GestureDetector]. Idempotent. */
+    fun attach(activity: Activity) {
+        val window = activity.window ?: return
+        val original = window.callback ?: return
+        if (original is InteractionCallback) return // already wrapped
+        val detector = GestureDetector(activity, GestureListener(window))
+        window.callback = InteractionCallback(original, detector)
+    }
+
+    /** Restore the original callback. Idempotent — safe if never attached. */
+    fun detach(activity: Activity) {
+        val window = activity.window ?: return
+        val cb = window.callback
+        if (cb is InteractionCallback) window.callback = cb.delegate
+    }
+
+    /**
+     * Resolve target, suppress secure surfaces, and emit the event + breadcrumb.
+     * Internal seam: exercised directly by tests without driving GestureDetector timing.
+     */
+    internal fun handleGesture(
+        window: Window,
+        type: String,
+        x: Float,
+        y: Float,
+        direction: String?
+    ) {
+        // Secure surfaces: suppress everything. FLAG_SECURE is a window flag here (view-level
+        // FLAG_SECURE on a SurfaceView is not readable via public API — window + password field
+        // are the detectable surfaces, per spec §Privacy residual).
+        if (isWindowSecure(window)) return
+
+        // x/y are window-relative pixels — the same space the decorView is hit-tested in, so the
+        // recorded point always aligns with the resolved target (no screen-vs-window skew).
+        val target = hitTest(window.decorView, x, y)
+        if (target is EditText && isPasswordInputType(target.inputType)) return // secure input: suppress
+
+        val name = target?.let { resolveTargetName(it) } ?: "unknown"
+        val attrs = mutableMapOf<String, Any>(
+            "ui.type" to type,
+            "ui.target" to name,
+            "ui.x" to x.toInt(),
+            "ui.y" to y.toInt()
+        )
+        if (direction != null) attrs["ui.direction"] = direction
+        currentScreen()?.let { attrs["ui.screen"] = it }
+
+        telemetryManager.recordEvent("ui.interaction", attrs)
+        telemetryManager.addBreadcrumb("$type $name", category = "ui")
+    }
+
+    private inner class GestureListener(
+        private val window: Window
+    ) : GestureDetector.SimpleOnGestureListener() {
+
+        override fun onDown(e: MotionEvent): Boolean = true
+
+        override fun onSingleTapConfirmed(e: MotionEvent): Boolean {
+            handleGesture(window, "tap", e.x, e.y, null)
+            return false
+        }
+
+        override fun onLongPress(e: MotionEvent) {
+            handleGesture(window, "long_press", e.x, e.y, null)
+        }
+
+        override fun onFling(
+            e1: MotionEvent?,
+            e2: MotionEvent,
+            velocityX: Float,
+            velocityY: Float
+        ): Boolean {
+            handleGesture(window, "swipe", e2.x, e2.y, swipeDirection(velocityX, velocityY))
+            return false
+        }
+    }
+
+    /** Delegating [Window.Callback] that also feeds touches to a [GestureDetector]. */
+    internal class InteractionCallback(
+        val delegate: Window.Callback,
+        private val detector: GestureDetector
+    ) : Window.Callback by delegate {
+        override fun dispatchTouchEvent(event: MotionEvent): Boolean {
+            try {
+                detector.onTouchEvent(event)
+            } catch (_: Exception) {
+                // never let telemetry break input dispatch
+            }
+            return delegate.dispatchTouchEvent(event)
+        }
+    }
+}
+
+// --- Pure helpers (internal, unit-tested directly) ---
+
+/** Deepest View containing (x, y), searched child-first in reverse z-order. Null if outside root. */
+internal fun hitTest(root: View, x: Float, y: Float): View? {
+    if (!contains(root, x, y)) return null
+    if (root is ViewGroup) {
+        for (i in root.childCount - 1 downTo 0) {
+            val child = root.getChildAt(i)
+            if (child.visibility != View.VISIBLE) continue
+            val hit = hitTest(child, x - root.left, y - root.top)
+            if (hit != null) return hit
+        }
+    }
+    return root
+}
+
+private fun contains(v: View, x: Float, y: Float): Boolean =
+    x >= v.left && x < v.right && y >= v.top && y < v.bottom
+
+/** `getResourceEntryName` when the view has an id; else class simple name (compose surface mapped). */
+internal fun resolveTargetName(view: View): String {
+    val id = view.id
+    if (id != View.NO_ID) {
+        try {
+            return view.resources.getResourceEntryName(id)
+        } catch (_: Exception) {
+            // fall through to class name
+        }
+    }
+    // ponytail: Compose renders its whole tree in one AndroidComposeView (no per-composable id in
+    // the View tree). v1 is coordinate-only — map that surface to a stable name. Per-composable
+    // identity graduates via opt-in Modifier.trackTap (fog).
+    val simple = view.javaClass.simpleName
+    return if (simple == "AndroidComposeView") "compose_surface" else simple
+}
+
+internal fun swipeDirection(velocityX: Float, velocityY: Float): String =
+    if (abs(velocityX) > abs(velocityY)) {
+        if (velocityX > 0) "right" else "left"
+    } else {
+        if (velocityY > 0) "down" else "up"
+    }
+
+internal fun isWindowSecure(window: Window): Boolean =
+    (window.attributes.flags and WindowManager.LayoutParams.FLAG_SECURE) != 0
+
+/** True for text/number password variations — coordinates over these leak keystrokes (spec §Privacy). */
+internal fun isPasswordInputType(inputType: Int): Boolean {
+    val variation = inputType and (InputType.TYPE_MASK_CLASS or InputType.TYPE_MASK_VARIATION)
+    return variation == (InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_PASSWORD) ||
+        variation == (InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_WEB_PASSWORD) ||
+        variation == (InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD) ||
+        variation == (InputType.TYPE_CLASS_NUMBER or InputType.TYPE_NUMBER_VARIATION_PASSWORD)
+}

--- a/telemetry_library/src/test/java/com/androidtel/telemetry_library/core/interaction/UserInteractionTrackerTest.kt
+++ b/telemetry_library/src/test/java/com/androidtel/telemetry_library/core/interaction/UserInteractionTrackerTest.kt
@@ -1,0 +1,156 @@
+package com.androidtel.telemetry_library.core.interaction
+
+import android.app.Activity
+import android.text.InputType
+import android.view.View
+import android.view.WindowManager
+import android.widget.EditText
+import android.widget.FrameLayout
+import com.androidtel.telemetry_library.core.TelemetryManager
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Issue #58 / spec `user-interaction-events.md`. Drives the internal gesture seam directly so the
+ * hit-test → secure-suppression → emit contract is asserted without fighting GestureDetector timing.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [28])
+class UserInteractionTrackerTest {
+
+    private fun activityWith(root: View): Activity {
+        val activity = Robolectric.buildActivity(Activity::class.java).setup().get()
+        activity.setContentView(root)
+        // Lay out the whole decorView so the hierarchy above `root` (content frame, etc.) has real
+        // bounds — hit-testing traverses from decorView down and skips zero-bound ancestors otherwise.
+        val decor = activity.window.decorView
+        decor.measure(
+            View.MeasureSpec.makeMeasureSpec(1080, View.MeasureSpec.EXACTLY),
+            View.MeasureSpec.makeMeasureSpec(1920, View.MeasureSpec.EXACTLY)
+        )
+        decor.layout(0, 0, 1080, 1920)
+        return activity
+    }
+
+    @Test
+    fun `tap on a view with an id emits one ui_interaction with matching target`() {
+        val manager = mockk<TelemetryManager>(relaxed = true)
+        val tracker = UserInteractionTracker(manager) { "CheckoutActivity" }
+
+        val button = View(Robolectric.buildActivity(Activity::class.java).get()).apply {
+            id = View.generateViewId()
+        }
+        val root = FrameLayout(Robolectric.buildActivity(Activity::class.java).get()).apply {
+            addView(button)
+        }
+        val activity = activityWith(root)
+        button.layout(0, 0, 1080, 1920) // give the child real bounds Robolectric won't measure
+
+        val attrs = slot<Map<String, Any>>()
+        tracker.handleGesture(activity.window, "tap", 540f, 1000f, null)
+
+        verify(exactly = 1) { manager.recordEvent(eq("ui.interaction"), capture(attrs)) }
+        verify(exactly = 1) { manager.addBreadcrumb(any(), eq("ui"), any(), any()) }
+        assertEquals("tap", attrs.captured["ui.type"])
+        assertEquals("View", attrs.captured["ui.target"]) // generateViewId ⇒ class fallback
+        assertEquals("CheckoutActivity", attrs.captured["ui.screen"])
+        assertEquals(540, attrs.captured["ui.x"])
+        assertFalse(attrs.captured.containsKey("ui.direction"))
+    }
+
+    @Test
+    fun `tap on a password EditText emits nothing`() {
+        val manager = mockk<TelemetryManager>(relaxed = true)
+        val tracker = UserInteractionTracker(manager) { "LoginActivity" }
+
+        val ctx = Robolectric.buildActivity(Activity::class.java).get()
+        val password = EditText(ctx).apply {
+            inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_PASSWORD
+        }
+        val root = FrameLayout(ctx).apply { addView(password) }
+        val activity = activityWith(root)
+        password.layout(0, 0, 1080, 1920)
+
+        tracker.handleGesture(activity.window, "tap", 540f, 1000f, null)
+
+        verify(exactly = 0) { manager.recordEvent(any(), any()) }
+    }
+
+    @Test
+    fun `tap on a FLAG_SECURE window emits nothing`() {
+        val manager = mockk<TelemetryManager>(relaxed = true)
+        val tracker = UserInteractionTracker(manager) { "SecretActivity" }
+
+        val ctx = Robolectric.buildActivity(Activity::class.java).get()
+        val root = FrameLayout(ctx).apply { addView(View(ctx).apply { id = View.generateViewId() }) }
+        val activity = activityWith(root)
+        activity.window.setFlags(
+            WindowManager.LayoutParams.FLAG_SECURE,
+            WindowManager.LayoutParams.FLAG_SECURE
+        )
+
+        tracker.handleGesture(activity.window, "tap", 5f, 5f, null)
+
+        verify(exactly = 0) { manager.recordEvent(any(), any()) }
+    }
+
+    @Test
+    fun `swipe records direction and exactly one event`() {
+        val manager = mockk<TelemetryManager>(relaxed = true)
+        val tracker = UserInteractionTracker(manager) { "FeedActivity" }
+
+        val ctx = Robolectric.buildActivity(Activity::class.java).get()
+        val root = FrameLayout(ctx)
+        val activity = activityWith(root)
+
+        val attrs = slot<Map<String, Any>>()
+        tracker.handleGesture(activity.window, "swipe", 100f, 100f, "left")
+
+        verify(exactly = 1) { manager.recordEvent(eq("ui.interaction"), capture(attrs)) }
+        assertEquals("swipe", attrs.captured["ui.type"])
+        assertEquals("left", attrs.captured["ui.direction"])
+    }
+
+    // --- pure helpers ---
+
+    @Test
+    fun `swipeDirection resolves from dominant velocity axis`() {
+        assertEquals("right", swipeDirection(500f, 10f))
+        assertEquals("left", swipeDirection(-500f, 10f))
+        assertEquals("down", swipeDirection(10f, 500f))
+        assertEquals("up", swipeDirection(10f, -500f))
+    }
+
+    @Test
+    fun `isPasswordInputType covers text and number password variations`() {
+        assertTrue(isPasswordInputType(InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_PASSWORD))
+        assertTrue(isPasswordInputType(InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD))
+        assertTrue(isPasswordInputType(InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_WEB_PASSWORD))
+        assertTrue(isPasswordInputType(InputType.TYPE_CLASS_NUMBER or InputType.TYPE_NUMBER_VARIATION_PASSWORD))
+        assertFalse(isPasswordInputType(InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_NORMAL))
+    }
+
+    @Test
+    fun `resolveTargetName maps compose surface class to compose_surface`() {
+        // plain View with no id falls back to class simple name
+        val ctx = Robolectric.buildActivity(Activity::class.java).get()
+        assertEquals("View", resolveTargetName(View(ctx)))
+    }
+
+    @Test
+    fun `hitTest returns null outside root bounds`() {
+        val ctx = Robolectric.buildActivity(Activity::class.java).get()
+        val root = View(ctx).apply { layout(0, 0, 100, 100) }
+        assertNull(hitTest(root, 200f, 200f))
+    }
+}


### PR DESCRIPTION
Closes #58.

Adds the new `ui.interaction` datapoint (Wave 3 of PRD #45), per `docs/specs/user-interaction-events.md`.

## What
`UserInteractionTracker` wraps the Activity `Window.Callback` on resume (restores on pause), feeds a `GestureDetector`, and emits **one `ui.interaction` event per completed gesture** discriminated by `ui.type` (`tap` / `long_press` / `swipe`). Wired into `TelemetryActivityLifecycleObserver`, gated by the existing `enableUserInteractionEvents` flag (default true), reusing the observer's `NavigationStackTracker` for `ui.screen`.

Event attributes: `ui.type`, `ui.target`, `ui.x`, `ui.y`, `ui.direction` (swipe only), `ui.screen`. Plus a compact `addBreadcrumb("$type $target", category = "ui")` per interaction for the crash trail.

- **Target resolution:** `getResourceEntryName(id)` → View class simple-name fallback; Compose surface mapped to `compose_surface` (coordinate-only v1).
- **Privacy (hard default, not a config flag):** capture suppressed on secure surfaces — password-`inputType` `EditText` or `FLAG_SECURE` window emit nothing.
- **Coordinates:** window-relative pixels, recorded in the same space the decorView is hit-tested (no screen-vs-window skew).

## Acceptance criteria (#58)
- [x] `ui.interaction` emitted, discriminated by `ui.type` tap/long_press/swipe
- [x] Capture suppressed on password `inputType` / `FLAG_SECURE` surfaces
- [x] Target resolves via `getResourceEntryName` → class fallback; raw x/y recorded
- [x] Compact interaction breadcrumb appears in the crash trail

## Tests
8 tests via the internal `handleGesture` seam (tap target match, password-EditText suppression, FLAG_SECURE suppression, swipe direction) plus pure helpers (`swipeDirection`, `isPasswordInputType`, `resolveTargetName`, `hitTest`).

`testDebugUnitTest` + `lintDebug` + `assembleRelease` all green.

## Out of scope (spec fog)
Per-composable Compose identity (`Modifier.trackTap`), content-desc targets, normalized coords, scroll/drag/double-tap, custom-keypad PII rule — graduate individually when a consumer or the hub forces it.