### PR TITLE
feat(#59): distributed trace/span contract — W3C traceparent + span attrs

### DIFF
--- a/telemetry_library/src/main/java/com/androidtel/telemetry_library/compose/EdgeTelemetryCompose.kt
+++ b/telemetry_library/src/main/java/com/androidtel/telemetry_library/compose/EdgeTelemetryCompose.kt
@@ -9,6 +9,7 @@ import androidx.navigation.compose.currentBackStackEntryAsState
 import com.androidtel.telemetry_library.EdgeTelemetry
 import com.androidtel.telemetry_library.core.navigation.NavigationStackTracker
 import com.androidtel.telemetry_library.core.TelemetryTime
+import com.androidtel.telemetry_library.core.trace.TraceManager
 
 /**
  * Enhanced Compose integration for EdgeTelemetry that provides automatic navigation tracking
@@ -70,8 +71,9 @@ fun TrackComposeScreen(
             data = breadcrumbData
         )
         
-        // Track navigation event
-        EdgeTelemetry.getInstance().recordEvent("navigation", eventData)
+        // Track navigation event — child of a recent interaction (tap→nav) else a new trace root (#59).
+        val trace = TraceManager.onNavigation(System.currentTimeMillis()) ?: emptyMap()
+        EdgeTelemetry.getInstance().recordEvent("navigation", eventData + trace)
         
         onDispose {
             val duration = System.currentTimeMillis() - startTime

--- a/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/TelemetryActivityLifecycleObserver.kt
+++ b/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/TelemetryActivityLifecycleObserver.kt
@@ -8,6 +8,7 @@ import android.util.Log
 import androidx.fragment.app.FragmentActivity
 import com.androidtel.telemetry_library.core.interaction.UserInteractionTracker
 import com.androidtel.telemetry_library.core.navigation.NavigationStackTracker
+import com.androidtel.telemetry_library.core.trace.TraceManager
 
 class TelemetryActivityLifecycleObserver(
     private val telemetryManager: TelemetryManager = TelemetryManager.getInstance()
@@ -52,17 +53,17 @@ class TelemetryActivityLifecycleObserver(
 
         // Track navigation with proper structure
         val navEvent = navigationTracker.push(screenName)
-        telemetryManager.recordEvent(
-            eventName = "navigation",
-            attributes = mapOf(
-                "navigation.from_screen" to (navEvent.fromScreen ?: ""),
-                "navigation.to_screen" to navEvent.toScreen,
-                "navigation.method" to navEvent.method.toLowerCaseString(),
-                "navigation.route_type" to detectRouteType(activity),
-                "navigation.has_arguments" to hasIntentExtras(activity),
-                "navigation.timestamp" to navEvent.timestamp
-            )
+        val navAttributes = mutableMapOf<String, Any>(
+            "navigation.from_screen" to (navEvent.fromScreen ?: ""),
+            "navigation.to_screen" to navEvent.toScreen,
+            "navigation.method" to navEvent.method.toLowerCaseString(),
+            "navigation.route_type" to detectRouteType(activity),
+            "navigation.has_arguments" to hasIntentExtras(activity),
+            "navigation.timestamp" to navEvent.timestamp
         )
+        // Child of a recent interaction (tap→nav) else a new trace root (#59).
+        TraceManager.onNavigation(System.currentTimeMillis())?.let { navAttributes.putAll(it) }
+        telemetryManager.recordEvent(eventName = "navigation", attributes = navAttributes)
     }
 
     override fun onActivityPaused(activity: Activity) {

--- a/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/TelemetryConfig.kt
+++ b/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/TelemetryConfig.kt
@@ -15,7 +15,8 @@ data class TelemetryConfig(
     val enableFrameTracking: Boolean = true,
     val enableUserInteractionEvents: Boolean = true,
     val enableCapabilityEvents: Boolean = true,
-    val enableSessionTracking: Boolean = true
+    val enableSessionTracking: Boolean = true,
+    val traceSampleRate: Double = 1.0
 ) {
     init {
         require(apiKey.isNotBlank()) { "apiKey must not be blank" }
@@ -24,5 +25,6 @@ data class TelemetryConfig(
         require(batchSize > 0) { "batchSize must be > 0" }
         require(flushIntervalMs > 0) { "flushIntervalMs must be > 0" }
         require(sessionTimeoutMs > 0) { "sessionTimeoutMs must be > 0" }
+        require(traceSampleRate in 0.0..1.0) { "traceSampleRate must be in 0.0..1.0" }
     }
 }

--- a/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/TelemetryFragmentLifecycleObserver.kt
+++ b/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/TelemetryFragmentLifecycleObserver.kt
@@ -8,6 +8,7 @@ import android.view.View
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import com.androidtel.telemetry_library.core.navigation.NavigationStackTracker
+import com.androidtel.telemetry_library.core.trace.TraceManager
 
 class TelemetryFragmentLifecycleObserver(private val telemetryManager: TelemetryManager = TelemetryManager.getInstance()) :
     FragmentManager.FragmentLifecycleCallbacks() {
@@ -25,6 +26,8 @@ class TelemetryFragmentLifecycleObserver(private val telemetryManager: Telemetry
 
         // Track navigation with proper structure
         val navEvent = navigationTracker.push(fragmentName)
+        // Child of a recent interaction (tap→nav) else a new trace root (#59).
+        val trace = TraceManager.onNavigation(System.currentTimeMillis()) ?: emptyMap()
         telemetryManager.recordEvent(
             eventName = "navigation",
             attributes = mapOf(
@@ -34,7 +37,7 @@ class TelemetryFragmentLifecycleObserver(private val telemetryManager: Telemetry
                 "navigation.route_type" to "fragment_flow",
                 "navigation.has_arguments" to (f.arguments?.isEmpty == false),
                 "navigation.timestamp" to navEvent.timestamp
-            )
+            ) + trace
         )
     }
 

--- a/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/TelemetryInterceptor.kt
+++ b/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/TelemetryInterceptor.kt
@@ -1,5 +1,6 @@
 package com.androidtel.telemetry_library.core
 
+import com.androidtel.telemetry_library.core.trace.TraceManager
 import okhttp3.Interceptor
 import okhttp3.Response
 import java.util.concurrent.TimeUnit
@@ -18,11 +19,19 @@ class TelemetryInterceptor(
             return chain.proceed(request)
         }
         
+        // Distributed trace child span (#59): mint one under the current root, inject the W3C
+        // traceparent, and stamp the trace attrs on http.request. If the caller already set a
+        // traceparent, don't overwrite it (and don't stamp our attrs); no sampled root → no trace.
+        val trace = if (request.header("traceparent") == null) TraceManager.onNetworkCall() else null
+        val outgoing = trace?.let {
+            request.newBuilder().header("traceparent", it.first).build()
+        } ?: request
+
         val startTime = System.nanoTime()
         var response: Response? = null
 
         try {
-            response = chain.proceed(request)
+            response = chain.proceed(outgoing)
             return response
         } finally {
             val endTime = System.nanoTime()
@@ -39,6 +48,7 @@ class TelemetryInterceptor(
                 // "optional pair", so the backend column stays null rather than a false 0.
                 request.body?.contentLength()?.takeIf { it >= 0 }?.let { put("http.request_size", it) }
                 response?.body?.contentLength()?.takeIf { it >= 0 }?.let { put("http.response_size", it) }
+                trace?.let { putAll(it.second) }
             }
 
             telemetryManager.recordEvent(eventName = "http.request", attributes = attributes)

--- a/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/TelemetryManager.kt
+++ b/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/TelemetryManager.kt
@@ -16,6 +16,7 @@ import androidx.navigation.NavController
 import com.androidtel.telemetry_library.core.breadcrumbs.BreadcrumbManager
 import com.androidtel.telemetry_library.core.device.DeviceInfoCollector
 import com.androidtel.telemetry_library.core.ids.IdGenerator
+import com.androidtel.telemetry_library.core.trace.TraceManager
 import com.androidtel.telemetry_library.core.models.AppInfo
 import com.androidtel.telemetry_library.core.services.EventTrackingService
 import com.androidtel.telemetry_library.core.services.SessionService
@@ -242,6 +243,7 @@ class TelemetryManager private constructor(
         try {
             // Step 1: Config already validated in TelemetryConfig.init
             Log.d("TelemetryManager", "Step 1: Config validated")
+            TraceManager.traceSampleRate = config.traceSampleRate
             
             // Step 2: Restore or generate deviceId
             idGenerator = IdGenerator()
@@ -472,6 +474,9 @@ class TelemetryManager private constructor(
         
         // 3. Pause the flush timer
         batchProcessingService.stopFlushTimer()
+
+        // 4. Clear the current trace root so a background sync doesn't attach to a stale tap (#59).
+        TraceManager.onBackground()
     }
 
     // Records a new metric event with the specified details.
@@ -544,6 +549,8 @@ class TelemetryManager private constructor(
     // --- Screen Navigation Tracking for Jetpack Compose ---
     fun recordComposeScreenView(screenRoute: String) {
         screenTimingTracker.startScreen(screenRoute)
+        // Child of a recent interaction (tap→nav) else a new trace root (#59).
+        val trace = TraceManager.onNavigation(System.currentTimeMillis()) ?: emptyMap()
         recordEvent(
             eventName = "navigation",
             attributes = mapOf(
@@ -553,7 +560,7 @@ class TelemetryManager private constructor(
                 "navigation.route_type" to "compose_route",
                 "navigation.has_arguments" to false,
                 "navigation.timestamp" to TelemetryTime.now()
-            )
+            ) + trace
         )
     }
 

--- a/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/ids/IdGenerator.kt
+++ b/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/ids/IdGenerator.kt
@@ -12,6 +12,26 @@ class IdGenerator {
         private const val KEY_USER_ID = "edge_rum_user_id"
 
         private val secureRandom = SecureRandom()
+
+        /** W3C Trace Context trace-id: 32 lowercase hex (128-bit). Raw hex, not a join key (#43). */
+        fun traceId(): String = randomHex(16)
+
+        /** W3C Trace Context span-id: 16 lowercase hex (64-bit). */
+        fun spanId(): String = randomHex(8)
+
+        /** `2 * byteCount` lowercase hex chars from the shared crypto RNG. */
+        private fun randomHex(byteCount: Int): String {
+            val bytes = ByteArray(byteCount)
+            synchronized(secureRandom) {
+                secureRandom.nextBytes(bytes)
+            }
+            val sb = StringBuilder(byteCount * 2)
+            for (b in bytes) {
+                sb.append(Character.forDigit((b.toInt() shr 4) and 0xF, 16))
+                sb.append(Character.forDigit(b.toInt() and 0xF, 16))
+            }
+            return sb.toString()
+        }
     }
     
     @Volatile
@@ -64,16 +84,5 @@ class IdGenerator {
     }
 
     // 16 lowercase hex chars (64 bits) from crypto RNG.
-    private fun hex16(): String {
-        val bytes = ByteArray(8)
-        synchronized(secureRandom) {
-            secureRandom.nextBytes(bytes)
-        }
-        val sb = StringBuilder(16)
-        for (b in bytes) {
-            sb.append(Character.forDigit((b.toInt() shr 4) and 0xF, 16))
-            sb.append(Character.forDigit(b.toInt() and 0xF, 16))
-        }
-        return sb.toString()
-    }
+    private fun hex16(): String = randomHex(8)
 }

--- a/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/interaction/UserInteractionTracker.kt
+++ b/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/interaction/UserInteractionTracker.kt
@@ -10,6 +10,7 @@ import android.view.Window
 import android.view.WindowManager
 import android.widget.EditText
 import com.androidtel.telemetry_library.core.TelemetryManager
+import com.androidtel.telemetry_library.core.trace.TraceManager
 import kotlin.math.abs
 
 /**
@@ -72,6 +73,10 @@ class UserInteractionTracker(
         )
         if (direction != null) attrs["ui.direction"] = direction
         currentScreen()?.let { attrs["ui.screen"] = it }
+
+        // A user interaction always opens a fresh trace root (#59). Stamp trace.id/span.id when
+        // sampled; null (unsampled) leaves the event with no trace attrs.
+        TraceManager.onInteraction(System.currentTimeMillis())?.let { attrs.putAll(it) }
 
         telemetryManager.recordEvent("ui.interaction", attrs)
         telemetryManager.addBreadcrumb("$type $name", category = "ui")

--- a/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/trace/TraceManager.kt
+++ b/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/trace/TraceManager.kt
@@ -1,0 +1,85 @@
+package com.androidtel.telemetry_library.core.trace
+
+import com.androidtel.telemetry_library.core.ids.IdGenerator
+import java.security.SecureRandom
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Distributed trace/span contract (issue #59 / spec `distributed-trace-span.md`).
+ *
+ * The whole contract is this one process-global "current root" holder plus four call sites:
+ * an interaction opens a root, a nav is its child (if recent) else a new root, each network call
+ * is a child that injects a W3C `traceparent`, and backgrounding clears the root. Spans are
+ * expressed as `trace.id`/`span.id`/`parent.span.id` attributes on existing events — no new event
+ * type, no span-start/-end emission.
+ *
+ * ceiling: current root is a single process-global AtomicReference, not per-coroutine context, so a
+ * call fired from a stale foreground screen can attach to the wrong root. Accurate parenting needs
+ * coroutine/thread context propagation — deferred to fog. Fine for the tap→calls 95% case.
+ */
+object TraceManager {
+
+    data class TraceContext(
+        val traceId: String,
+        val spanId: String,
+        val sampled: Boolean,
+        val startedAtMs: Long
+    )
+
+    private const val ROOT_LINK_WINDOW_MS = 1000L
+
+    private val current = AtomicReference<TraceContext?>(null)
+    private val secureRandom = SecureRandom()
+
+    /** Head-based sampling rate, set from `TelemetryConfig.traceSampleRate` at init. */
+    @Volatile
+    var traceSampleRate: Double = 1.0
+
+    /**
+     * #42 interaction observer. Always a fresh root: roll sampling, mint a trace + root span,
+     * replace the current root. Returns the two attrs to stamp on `ui.interaction` (no
+     * `parent.span.id` on a root), or null when the trace is not sampled.
+     */
+    fun onInteraction(nowMs: Long): Map<String, Any>? {
+        val sampled = secureRandom.nextDouble() < traceSampleRate
+        val ctx = TraceContext(IdGenerator.traceId(), IdGenerator.spanId(), sampled, nowMs)
+        current.set(if (sampled) ctx else null)
+        return if (sampled) mapOf("trace.id" to ctx.traceId, "span.id" to ctx.spanId) else null
+    }
+
+    /**
+     * Screen tracker. Child of the current root if it opened within [ROOT_LINK_WINDOW_MS]
+     * (tap→navigate), else this nav opens its own new root (cold start, deep link, programmatic).
+     */
+    fun onNavigation(nowMs: Long): Map<String, Any>? {
+        val root = current.get()
+        if (root != null && root.sampled && nowMs - root.startedAtMs <= ROOT_LINK_WINDOW_MS) {
+            return childAttrs(root)
+        }
+        return onInteraction(nowMs) // no recent root → this nav IS the root
+    }
+
+    /**
+     * #40 interceptor, per request. Mint a child span under the current sampled root and return
+     * `(traceparentHeader, eventAttrs)`, or null when there is no sampled root (e.g. a background
+     * call after [onBackground]) — such a call carries no header and no trace attrs.
+     */
+    fun onNetworkCall(): Pair<String, Map<String, Any>>? {
+        val root = current.get()?.takeIf { it.sampled } ?: return null
+        val attrs = childAttrs(root)
+        val header = "00-${root.traceId}-${attrs["span.id"]}-01"
+        return header to attrs
+    }
+
+    /** Mint a fresh child span under [root]: the three trace attrs a child event carries. */
+    private fun childAttrs(root: TraceContext): Map<String, Any> = mapOf(
+        "trace.id" to root.traceId,
+        "span.id" to IdGenerator.spanId(),
+        "parent.span.id" to root.spanId
+    )
+
+    /** ProcessLifecycleOwner `onStop` (already wired). Clears the root so a background sync does not attach to a stale tap. */
+    fun onBackground() {
+        current.set(null)
+    }
+}

--- a/telemetry_library/src/test/java/com/androidtel/telemetry_library/core/TelemetryInterceptorTest.kt
+++ b/telemetry_library/src/test/java/com/androidtel/telemetry_library/core/TelemetryInterceptorTest.kt
@@ -1,5 +1,6 @@
 package com.androidtel.telemetry_library.core
 
+import com.androidtel.telemetry_library.core.trace.TraceManager
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
@@ -10,6 +11,7 @@ import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -40,6 +42,8 @@ class TelemetryInterceptorTest {
         // Release non-daemon OkHttp threads so the suite doesn't hang (see takerequest gotcha).
         client.dispatcher.executorService.shutdown()
         client.connectionPool.evictAll()
+        TraceManager.traceSampleRate = 1.0
+        TraceManager.onBackground()
     }
 
     @Test
@@ -67,5 +71,53 @@ class TelemetryInterceptorTest {
         assertEquals(0, recorded.captured["http.status_code"])
         assertEquals(false, recorded.captured["http.success"])
         assertFalse(recorded.captured.containsKey("http.error"))
+    }
+
+    @Test
+    fun `sampled root injects traceparent and stamps child span attrs`() {
+        TraceManager.traceSampleRate = 1.0
+        TraceManager.onBackground()
+        val root = TraceManager.onInteraction(System.currentTimeMillis())!!
+        server.enqueue(MockResponse().setResponseCode(200))
+
+        client.newCall(Request.Builder().url(server.url("/x")).build()).execute().close()
+
+        val sent = server.takeRequest().getHeader("traceparent")!!
+        assertTrue("well-formed traceparent", Regex("^00-[0-9a-f]{32}-[0-9a-f]{16}-01$").matches(sent))
+        assertTrue("carries the root trace id", sent.contains(root["trace.id"] as String))
+
+        val a = recorded.captured
+        assertEquals(root["trace.id"], a["trace.id"])
+        assertEquals(root["span.id"], a["parent.span.id"])
+        assertTrue(sent.contains(a["span.id"] as String))
+    }
+
+    @Test
+    fun `no active root injects no header and no trace attrs`() {
+        TraceManager.traceSampleRate = 1.0
+        TraceManager.onBackground() // no root
+        server.enqueue(MockResponse().setResponseCode(200))
+
+        client.newCall(Request.Builder().url(server.url("/x")).build()).execute().close()
+
+        assertNull("no header when no root", server.takeRequest().getHeader("traceparent"))
+        assertFalse(recorded.captured.containsKey("trace.id"))
+    }
+
+    @Test
+    fun `existing traceparent is not overwritten`() {
+        TraceManager.traceSampleRate = 1.0
+        TraceManager.onBackground()
+        TraceManager.onInteraction(System.currentTimeMillis()) // active root exists
+        val appHeader = "00-abcdef01234567890abcdef012345678-1122334455667788-01"
+        server.enqueue(MockResponse().setResponseCode(200))
+
+        client.newCall(
+            Request.Builder().url(server.url("/x")).header("traceparent", appHeader).build()
+        ).execute().close()
+
+        assertEquals(appHeader, server.takeRequest().getHeader("traceparent"))
+        assertFalse("we don't stamp our attrs when caller owns the header",
+            recorded.captured.containsKey("trace.id"))
     }
 }

--- a/telemetry_library/src/test/java/com/androidtel/telemetry_library/core/ids/IdGeneratorTest.kt
+++ b/telemetry_library/src/test/java/com/androidtel/telemetry_library/core/ids/IdGeneratorTest.kt
@@ -600,6 +600,24 @@ class IdGeneratorTest {
         assertTrue("Session ID must start with session_", sessionId.startsWith("session_"))
     }
 
+    // --- W3C trace/span raw-hex helpers (#59) ---
+
+    @Test
+    fun `traceId is 32 lowercase hex`() {
+        repeat(100) { assertTrue(Regex("^[0-9a-f]{32}$").matches(IdGenerator.traceId())) }
+    }
+
+    @Test
+    fun `spanId is 16 lowercase hex`() {
+        repeat(100) { assertTrue(Regex("^[0-9a-f]{16}$").matches(IdGenerator.spanId())) }
+    }
+
+    @Test
+    fun `trace and span ids are collision-free over 1000`() {
+        assertEquals(1000, (1..1000).map { IdGenerator.traceId() }.toSet().size)
+        assertEquals(1000, (1..1000).map { IdGenerator.spanId() }.toSet().size)
+    }
+
     @Test
     fun `fresh install - device user session all mint new format`() {
         `when`(mockPrefs.getString("device_id", null)).thenReturn(null)

--- a/telemetry_library/src/test/java/com/androidtel/telemetry_library/core/trace/TraceManagerTest.kt
+++ b/telemetry_library/src/test/java/com/androidtel/telemetry_library/core/trace/TraceManagerTest.kt
@@ -1,0 +1,111 @@
+package com.androidtel.telemetry_library.core.trace
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class TraceManagerTest {
+
+    private val traceIdRegex = Regex("^[0-9a-f]{32}$")
+    private val spanIdRegex = Regex("^[0-9a-f]{16}$")
+    private val headerRegex = Regex("^00-[0-9a-f]{32}-[0-9a-f]{16}-01$")
+
+    @Before
+    fun setup() {
+        TraceManager.traceSampleRate = 1.0
+        TraceManager.onBackground() // clear any root leaked from another test
+    }
+
+    @After
+    fun teardown() {
+        TraceManager.traceSampleRate = 1.0
+        TraceManager.onBackground()
+    }
+
+    // 1. Interaction opens a root — trace.id + span.id, no parent.span.id.
+    @Test
+    fun `interaction opens a root with trace and span ids, no parent`() {
+        val attrs = TraceManager.onInteraction(1_000L)!!
+        assertTrue(traceIdRegex.matches(attrs["trace.id"] as String))
+        assertTrue(spanIdRegex.matches(attrs["span.id"] as String))
+        assertFalse("root has no parent", attrs.containsKey("parent.span.id"))
+    }
+
+    // 2. Tap → network child — same trace, fresh span, parent == root span; header well-formed.
+    @Test
+    fun `network call after interaction is a child with matching header`() {
+        val root = TraceManager.onInteraction(1_000L)!!
+        val (header, attrs) = TraceManager.onNetworkCall()!!
+
+        assertEquals(root["trace.id"], attrs["trace.id"])
+        assertEquals(root["span.id"], attrs["parent.span.id"])
+        assertTrue(spanIdRegex.matches(attrs["span.id"] as String))
+        assertTrue("child span differs from root", attrs["span.id"] != root["span.id"])
+        assertTrue(headerRegex.matches(header))
+        assertTrue(header.contains(root["trace.id"] as String))
+        assertTrue(header.contains(attrs["span.id"] as String))
+    }
+
+    // 3. Navigation linkage — within 1000ms is a child; a cold nav opens a new root.
+    @Test
+    fun `nav within window is a child of the interaction root`() {
+        val root = TraceManager.onInteraction(1_000L)!!
+        val nav = TraceManager.onNavigation(1_900L)!! // 900ms later
+
+        assertEquals(root["trace.id"], nav["trace.id"])
+        assertEquals(root["span.id"], nav["parent.span.id"])
+    }
+
+    @Test
+    fun `nav outside window opens a new root`() {
+        val root = TraceManager.onInteraction(1_000L)!!
+        val nav = TraceManager.onNavigation(2_100L)!! // 1100ms later → own root
+
+        assertTrue("new trace", nav["trace.id"] != root["trace.id"])
+        assertFalse("root has no parent", nav.containsKey("parent.span.id"))
+    }
+
+    @Test
+    fun `cold nav with no root opens a new root`() {
+        val nav = TraceManager.onNavigation(5_000L)!!
+        assertTrue(traceIdRegex.matches(nav["trace.id"] as String))
+        assertFalse(nav.containsKey("parent.span.id"))
+    }
+
+    // 4. Background clears — a network call after onBackground has no trace.
+    @Test
+    fun `network call after background has no trace`() {
+        TraceManager.onInteraction(1_000L)
+        TraceManager.onBackground()
+        assertNull(TraceManager.onNetworkCall())
+    }
+
+    // 5. Sampling — 0.0 yields no trace anywhere; 1.0 yields trace everywhere.
+    @Test
+    fun `zero sample rate yields no trace attrs or header`() {
+        TraceManager.traceSampleRate = 0.0
+        assertNull(TraceManager.onInteraction(1_000L))
+        assertNull(TraceManager.onNetworkCall())
+        // A nav with no sampled root falls through to a new root, also unsampled.
+        assertNull(TraceManager.onNavigation(1_100L))
+    }
+
+    @Test
+    fun `full sample rate yields trace on every eligible call`() {
+        TraceManager.traceSampleRate = 1.0
+        assertTrue(TraceManager.onInteraction(1_000L) != null)
+        assertTrue(TraceManager.onNetworkCall() != null)
+    }
+
+    // Child inherits the sampled decision: an unsampled root means no network trace.
+    @Test
+    fun `network call has no trace when root was unsampled`() {
+        TraceManager.traceSampleRate = 0.0
+        TraceManager.onInteraction(1_000L) // unsampled root, current cleared
+        assertNull(TraceManager.onNetworkCall())
+    }
+}


### PR DESCRIPTION
Closes #59.

## What this does

Distributed trace/span visibility: an app action → the network calls it triggers → backend spans stitched into one trace. Implements the `docs/specs/distributed-trace-span.md` contract, android side only.

**`TraceManager`** (new, `core/trace/`) — one process-global current-root `AtomicReference` driving four call sites:
- **Interaction** → always a fresh root (`onInteraction`)
- **Navigation** → child of the root if within 1000ms (tap→nav), else its own new root (`onNavigation`)
- **Network call** → child span; injects `traceparent: 00-<32hex>-<16hex>-01` and stamps attrs on `http.request` (`onNetworkCall`)
- **Background** → clears the root so a background sync doesn't attach to a stale tap (`onBackground`)

Spans ride existing events as `trace.id` / `span.id` / `parent.span.id` attrs — no new event type, no span-start/-end emission. Root omits `parent.span.id`; children include it.

## Changes
- `IdGenerator`: raw-hex `traceId()` (32 hex) / `spanId()` (16 hex) on the existing `SecureRandom`; `hex16()` deduped onto the shared helper
- `TelemetryConfig`: `traceSampleRate` (default `1.0`, validated `0.0..1.0`), wired into `TraceManager` at init
- `TelemetryInterceptor`: injects `traceparent` before `proceed()` (does **not** overwrite a caller-set header); merges child-span attrs onto `http.request`; no sampled root → no header, no attrs
- `onNavigation()` wired on all four `navigation` emitters — Activity, Fragment, and both Compose paths — so Compose/Fragment apps open roots too
- `onBackground()` called from the already-wired `ProcessLifecycleOwner` `onStop`

## Sampling
Head-based, decided once at root open, inherited by every child. Unsampled root → no attrs / no header anywhere for that trace.

## Tests
- `TraceManagerTest` — root open, tap→network child, nav window (in/out of 1000ms), cold nav, background clears, sampling 0.0/1.0, unsampled-root inheritance
- `TelemetryInterceptorTest` — traceparent injection + child attrs, no-root case, existing-header no-overwrite
- `IdGeneratorTest` — trace/span hex format + collision checks

Full unit suite green.

## Note
`traceparent` injection is **inert until the backend reads it** (the spec's hard backend dependency) — this PR is the android side. Flat two-level tree (network calls parent to the root, not the nav span); deeper nesting, cross-coroutine parenting, `tracestate`, and a manual span API are deferred to fog per the spec.