### PR TITLE
feat(#60): ANR detection — AnrWatchdog + app.anr on durable rail

### DIFF
--- a/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/TelemetryManager.kt
+++ b/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/TelemetryManager.kt
@@ -13,6 +13,7 @@ import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ProcessLifecycleOwner
 import androidx.navigation.NavController
+import com.androidtel.telemetry_library.core.anr.AnrWatchdog
 import com.androidtel.telemetry_library.core.breadcrumbs.BreadcrumbManager
 import com.androidtel.telemetry_library.core.device.DeviceInfoCollector
 import com.androidtel.telemetry_library.core.ids.IdGenerator
@@ -26,12 +27,9 @@ import com.androidtel.telemetry_library.core.services.BatchProcessingService
 import com.androidtel.telemetry_library.core.models.DeviceInfo
 import com.androidtel.telemetry_library.core.models.EventAttributes
 import com.androidtel.telemetry_library.core.models.SessionInfo
-import com.androidtel.telemetry_library.core.models.TelemetryBatch
-import com.androidtel.telemetry_library.core.models.TelemetryEvent
 import com.androidtel.telemetry_library.core.models.UserInfo
 import com.androidtel.telemetry_library.core.session.SessionManager
 import com.androidtel.telemetry_library.core.user.UserProfileManager
-import com.google.gson.Gson
 import kotlinx.coroutines.CoroutineScope
 import okhttp3.Interceptor
 import kotlinx.coroutines.Dispatchers
@@ -114,7 +112,10 @@ class TelemetryManager private constructor(
     private lateinit var userProfileService: UserProfileService
     private lateinit var crashReportingService: CrashReportingService
     private lateinit var batchProcessingService: BatchProcessingService
-    
+
+    // Main-thread ANR watchdog (issue #60). Started on foreground, stopped on background.
+    private var anrWatchdog: AnrWatchdog? = null
+
     // Helper methods to check feature flags
     internal fun isMemoryTrackingEnabled(): Boolean = config.enableMemoryTracking
     internal fun isStorageTrackingEnabled(): Boolean = config.enableStorageTracking
@@ -216,6 +217,8 @@ class TelemetryManager private constructor(
          */
         @JvmStatic
         internal fun resetForTesting() {
+            // Stop the daemon so it doesn't keep posting heartbeats across tests (issue #60).
+            instance?.anrWatchdog?.stop()
             instance = null
         }
     }
@@ -328,6 +331,13 @@ class TelemetryManager private constructor(
                 }
             }
 
+            // Step 12b: Build the ANR watchdog BEFORE the lifecycle observer below, so a late init
+            // that happens while already foregrounded (addObserver replays onStart synchronously)
+            // still finds a non-null watchdog to arm (issue #60).
+            anrWatchdog = AnrWatchdog(onAnr = { durationMs, threads ->
+                crashReportingService.freezeAnr(durationMs, threads)
+            })
+
             // Step 13: Register ProcessLifecycleOwner observer if enabled
             if (config.enableLifecycleTracking && processObserverRegistered.compareAndSet(false, true)) {
                 ProcessLifecycleOwner.get().lifecycle.addObserver(this)
@@ -353,8 +363,12 @@ class TelemetryManager private constructor(
                 emitSessionStartedEvent()
             }
 
-            // Step 16: Replay a frozen fatal crash from a previous launch, if any (issue #56).
-            scope.launch { replayFatalCrashIfAny() }
+            // Step 16: Replay a frozen fatal crash from a previous launch, if any (issue #56), and a
+            // frozen ANR on the same durable rail (issue #60).
+            scope.launch {
+                replayFatalCrashIfAny()
+                replayPendingAnrIfAny()
+            }
 
         } catch (e: Exception) {
             Log.e("TelemetryManager", "Failed to complete initialization sequence", e)
@@ -454,6 +468,9 @@ class TelemetryManager private constructor(
 
         // 3. Sample memory on each foreground transition — bounded by user-engagement cadence
         sampleMemoryUsage()
+
+        // 4. Arm the ANR watchdog — foreground-only main-thread monitoring (issue #60).
+        anrWatchdog?.start()
     }
 
     // This is called when the app goes into the background. We can track the session end here.
@@ -477,6 +494,9 @@ class TelemetryManager private constructor(
 
         // 4. Clear the current trace root so a background sync doesn't attach to a stale tap (#59).
         TraceManager.onBackground()
+
+        // 5. Pause the ANR watchdog — background ANRs are out of scope for v1 (issue #60).
+        anrWatchdog?.stop()
     }
 
     // Records a new metric event with the specified details.
@@ -640,6 +660,19 @@ class TelemetryManager private constructor(
     // after a 2xx. Delegated to CrashReportingService.
     private suspend fun replayFatalCrashIfAny() {
         crashReportingService.replayFatalCrashIfAny()
+    }
+
+    /**
+     * ANR detected (issue #60). Runs on the watchdog thread — off the blocked main thread — so it can
+     * build the fully-enriched `app.anr` event and freeze it to the durable `filesDir` rail BEFORE
+     * the system may kill the app for the same hang. `is_fatal:false`/`handled:false`: a watchdog fire
+     * isn't a crash and wasn't caught by app code. Session/user are frozen at detection time by the
+     * standard enrichment. Delivered on next init via [replayPendingAnrIfAny], deleted only on a 2xx.
+     */
+    // ANR freeze/replay live on the durable-fatal rail owned by CrashReportingService (issue #60),
+    // alongside the crash freeze so the exactly-once discipline has one owner.
+    private suspend fun replayPendingAnrIfAny() {
+        crashReportingService.replayAnrIfAny()
     }
 
 

--- a/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/anr/AnrWatchdog.kt
+++ b/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/anr/AnrWatchdog.kt
@@ -1,0 +1,116 @@
+package com.androidtel.telemetry_library.core.anr
+
+import android.os.Handler
+import android.os.Looper
+import android.os.SystemClock
+
+/**
+ * One thread of every thread's stack, main flagged — the payload of an `app.anr` event (issue #60).
+ */
+data class ThreadDump(
+    val name: String,
+    val state: String,
+    val main: Boolean,
+    val stack: String
+)
+
+/**
+ * Main-thread watchdog (issue #60, spec `docs/specs/anr-detection.md`).
+ *
+ * A daemon thread posts a heartbeat to the main `Looper` and waits. If the main thread doesn't run
+ * the heartbeat within [THRESHOLD_MS] (Google's 5s ANR line), the main thread is blocked → capture an
+ * all-thread dump (main flagged) and hand it to [onAnr]. Works on minSdk 24, no API gate.
+ *
+ * Foreground-only: the SDK calls [start] on foreground and [stop] on background (spec §Lifecycle).
+ * Intra-hang dedup: one long hang fires exactly once — the fire latches until the main thread runs a
+ * heartbeat again (spec §6).
+ *
+ * ponytail: threshold + interval are internal constants, not config — the line is the platform's and
+ * won't vary per consumer. Upgrade path: promote to TelemetryConfig only if one needs a different line.
+ */
+class AnrWatchdog(
+    private val onAnr: (durationMs: Long, threads: List<ThreadDump>) -> Unit,
+    // Seams for unit testing (spec §Test plan, "Seam 2, fake clock"). Production reads the real clock
+    // and posts to the real main Looper.
+    private val mainHandler: Handler = Handler(Looper.getMainLooper()),
+    private val clock: () -> Long = { SystemClock.uptimeMillis() }
+) {
+    // Whether a heartbeat is outstanding, and when it was posted. A boolean flag (not a 0-sentinel on
+    // the timestamp) so a clock reading of 0 can't masquerade as "answered". @Volatile: the pong runs
+    // on the main thread, scanOnce on the watchdog thread.
+    @Volatile private var waiting = false
+    @Volatile private var pendingSince = 0L
+    // Latches after a fire so one hang = one event; cleared when the main thread finally answers.
+    @Volatile private var alreadyFired = false
+    @Volatile private var running = false
+    private var worker: Thread? = null
+
+    // The main thread runs this when it's free again: heartbeat answered, re-arm for the next hang.
+    private val pong = Runnable {
+        waiting = false
+        alreadyFired = false
+    }
+
+    fun start() {
+        if (running) return
+        running = true
+        waiting = false
+        alreadyFired = false
+        worker = Thread(::loop, THREAD_NAME).apply { isDaemon = true; start() }
+    }
+
+    fun stop() {
+        running = false
+        worker?.interrupt()
+        worker = null
+    }
+
+    private fun loop() {
+        while (running) {
+            scanOnce()
+            try {
+                Thread.sleep(INTERVAL_MS)
+            } catch (e: InterruptedException) {
+                break
+            }
+        }
+    }
+
+    /**
+     * One heartbeat cycle. Seam: tests drive this directly with a fake clock instead of the daemon
+     * loop. Snapshots `pending` once so a concurrent pong can't turn a live gap into a false positive.
+     */
+    internal fun scanOnce() {
+        if (!waiting) {
+            waiting = true
+            pendingSince = clock()
+            mainHandler.post(pong)
+            return
+        }
+        val blockedFor = clock() - pendingSince
+        if (!alreadyFired && blockedFor >= THRESHOLD_MS) {
+            alreadyFired = true
+            onAnr(blockedFor, captureThreads())
+        }
+    }
+
+    private fun captureThreads(): List<ThreadDump> {
+        val main = Looper.getMainLooper().thread
+        return Thread.getAllStackTraces().map { (thread, frames) ->
+            ThreadDump(
+                name = thread.name,
+                state = thread.state.name,
+                main = thread === main,
+                stack = frames.joinToString("\n") { "at $it" }
+            )
+        }
+    }
+
+    companion object {
+        // ponytail: fixed 5s — the system input-dispatch ANR line (spec §2).
+        const val THRESHOLD_MS = 5000L
+        // Heartbeat interval = threshold/2, floored at 500ms, so a real 5s hang is caught in one scan.
+        const val INTERVAL_MS = 2500L
+        private const val THREAD_NAME = "edge-anr-watchdog"
+    }
+}

--- a/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/crash/FatalCrashStore.kt
+++ b/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/crash/FatalCrashStore.kt
@@ -17,16 +17,20 @@ import java.io.FileOutputStream
  */
 internal object FatalCrashStore {
     private const val TAG = "FatalCrashStore"
-    private const val FILE_NAME = "pending_fatal_crash.json"
+    const val FILE_NAME = "pending_fatal_crash.json"
+    // ANR rides the same rail on its own slot (issue #60): same freeze → replay → delete-after-2xx,
+    // a separate file so a later fatal crash can't overwrite a pending ANR. is_fatal:false in the
+    // record distinguishes it downstream.
+    const val ANR_FILE_NAME = "pending_anr.json"
 
-    fun file(filesDir: File): File = File(filesDir, FILE_NAME)
+    fun file(filesDir: File, fileName: String = FILE_NAME): File = File(filesDir, fileName)
 
     /**
      * Synchronous, fsync'd write on the crashing thread. Blocks until the bytes are on disk so the
      * frozen crash survives an immediate process death.
      */
-    fun writeBlocking(filesDir: File, json: String) {
-        val f = file(filesDir)
+    fun writeBlocking(filesDir: File, json: String, fileName: String = FILE_NAME) {
+        val f = file(filesDir, fileName)
         f.parentFile?.mkdirs()
         FileOutputStream(f).use { fos ->
             fos.write(json.toByteArray(Charsets.UTF_8))
@@ -36,32 +40,38 @@ internal object FatalCrashStore {
     }
 
     /** Reads the frozen batch, or null if absent. A corrupt file is dropped so replay can't loop. */
-    fun readBatch(filesDir: File, gson: Gson): TelemetryBatch? {
-        val f = file(filesDir)
+    fun readBatch(filesDir: File, gson: Gson, fileName: String = FILE_NAME): TelemetryBatch? {
+        val f = file(filesDir, fileName)
         if (!f.exists() || f.length() == 0L) return null
         return try {
             gson.fromJson(f.readText(), TelemetryBatch::class.java)
         } catch (e: Exception) {
-            Log.e(TAG, "Corrupt fatal-crash file — deleting", e)
+            Log.e(TAG, "Corrupt frozen-event file $fileName — deleting", e)
             f.delete()
             null
         }
     }
 
-    fun delete(filesDir: File) {
-        val f = file(filesDir)
+    fun delete(filesDir: File, fileName: String = FILE_NAME) {
+        val f = file(filesDir, fileName)
         if (f.exists()) f.delete()
     }
 
     /**
-     * The exactly-once delivery invariant, in one place: send the frozen crash as-is, delete only on
+     * The exactly-once delivery invariant, in one place: send the frozen record as-is, delete only on
      * a 2xx. Returns true when there's nothing to send or it was delivered; false when it must be
-     * retried. Both replay rails (init + WorkManager) call this so the invariant can't drift.
+     * retried. Every replay rail (crash init, ANR init, WorkManager) calls this so the invariant
+     * can't drift.
      */
-    suspend fun replayOnce(filesDir: File, client: TelemetryHttpClient, gson: Gson = Gson()): Boolean {
-        val batch = readBatch(filesDir, gson) ?: return true
+    suspend fun replayOnce(
+        filesDir: File,
+        client: TelemetryHttpClient,
+        gson: Gson = Gson(),
+        fileName: String = FILE_NAME
+    ): Boolean {
+        val batch = readBatch(filesDir, gson, fileName) ?: return true
         return if (client.sendBatch(batch).isSuccess) {
-            delete(filesDir)
+            delete(filesDir, fileName)
             true
         } else {
             false

--- a/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/services/CrashReportingService.kt
+++ b/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/services/CrashReportingService.kt
@@ -5,8 +5,10 @@ import android.util.Log
 import com.androidtel.telemetry_library.core.TelemetryConfig
 import com.androidtel.telemetry_library.core.TelemetryHttpClient
 import com.androidtel.telemetry_library.core.TelemetryTime
+import com.androidtel.telemetry_library.core.anr.ThreadDump
 import com.androidtel.telemetry_library.core.breadcrumbs.BreadcrumbManager
 import com.androidtel.telemetry_library.core.crash.FatalCrashStore
+import com.androidtel.telemetry_library.core.navigation.NavigationStackTracker
 import com.androidtel.telemetry_library.core.models.EventAttributes
 import com.androidtel.telemetry_library.core.models.TelemetryBatch
 import com.androidtel.telemetry_library.core.models.TelemetryEvent
@@ -120,6 +122,45 @@ internal class CrashReportingService(
             Log.w(TAG, "Fatal crash replay failed; scheduling WorkManager retry")
             CrashReplay.schedule(context, config.apiKey, config.endpoint)
         }
+    }
+
+    // --- ANR durable-fatal rail (issue #60) ---
+
+    /**
+     * ANR detected by the watchdog. Runs on the watchdog thread — off the blocked main thread — so it
+     * builds a fully-enriched `app.anr` event and freezes it to its own slot on the durable `filesDir`
+     * rail BEFORE the system may kill the app for the same hang. `is_fatal:false`/`handled:false`: a
+     * watchdog fire isn't a crash and wasn't caught by app code. Session/user are frozen at detection
+     * time by the standard enrichment.
+     *
+     * ponytail: durable-only — freeze here, deliver on next init via [replayAnrIfAny]. Spec §5 also
+     * enqueues to the live batch for same-session delivery, but that double-sends (the live send
+     * doesn't delete the disk file, so replay re-sends next launch). Upgrade path: enqueue live AND
+     * delete the slot once that batch is acked, if surviving-process ANRs must report same-session.
+     */
+    fun freezeAnr(durationMs: Long, threads: List<ThreadDump>) {
+        val attrs = mapOf<String, Any>(
+            "is_fatal" to false,
+            "handled" to false,
+            "anr.duration_ms" to durationMs,
+            "screen.name" to (NavigationStackTracker.currentScreen() ?: ""),
+            "anr.threads" to threads
+        )
+        val enriched = buildAttributesFn?.invoke(attrs) ?: return
+        val event = TelemetryEvent(
+            type = "event",
+            eventName = "app.anr",
+            timestamp = TelemetryTime.now(),
+            attributes = enriched
+        )
+        val batch = TelemetryBatch(batchSize = 1, timestamp = TelemetryTime.now(), events = listOf(event))
+        FatalCrashStore.writeBlocking(context.filesDir, gson.toJson(batch), FatalCrashStore.ANR_FILE_NAME)
+    }
+
+    // Replay a frozen ANR from a previous launch; delete only on a 2xx. On failure the file survives
+    // and the next init retries — same exactly-once rail as the crash (#60).
+    suspend fun replayAnrIfAny() {
+        FatalCrashStore.replayOnce(context.filesDir, httpClient, gson, FatalCrashStore.ANR_FILE_NAME)
     }
 
     // --- Normal batch rail ---

--- a/telemetry_library/src/test/java/com/androidtel/telemetry_library/core/anr/AnrWatchdogTest.kt
+++ b/telemetry_library/src/test/java/com/androidtel/telemetry_library/core/anr/AnrWatchdogTest.kt
@@ -1,0 +1,170 @@
+package com.androidtel.telemetry_library.core.anr
+
+import android.os.Handler
+import android.os.Looper
+import com.androidtel.telemetry_library.release
+import com.androidtel.telemetry_library.core.TelemetryHttpClient
+import com.androidtel.telemetry_library.core.crash.FatalCrashStore
+import com.androidtel.telemetry_library.core.models.AppInfo
+import com.androidtel.telemetry_library.core.models.DeviceInfo
+import com.androidtel.telemetry_library.core.models.EventAttributes
+import com.androidtel.telemetry_library.core.models.SessionInfo
+import com.androidtel.telemetry_library.core.models.TelemetryBatch
+import com.androidtel.telemetry_library.core.models.TelemetryEvent
+import com.androidtel.telemetry_library.core.models.UserInfo
+import com.google.gson.Gson
+import com.google.gson.JsonParser
+import kotlinx.coroutines.runBlocking
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import java.util.concurrent.TimeUnit
+
+/**
+ * Issue #60 conformance (spec `docs/specs/anr-detection.md`): a main-thread watchdog fires exactly
+ * one `app.anr` past the 5s line with an all-thread dump (main flagged), a healthy main thread fires
+ * nothing, and the event delivers on the durable `filesDir` rail (freeze → replay → delete-after-2xx).
+ *
+ * The watchdog's [AnrWatchdog.scanOnce] seam is driven directly with a fake clock — no real daemon
+ * thread, no wall-clock sleeps. "Main thread blocked" = leaving the Robolectric main looper paused so
+ * the posted heartbeat never runs; "healthy" = idling the looper so it does.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [28], manifest = Config.NONE)
+class AnrWatchdogTest {
+
+    private var fakeNow = 0L
+    private val fires = mutableListOf<Pair<Long, List<ThreadDump>>>()
+    private lateinit var watchdog: AnrWatchdog
+
+    @Before
+    fun setUp() {
+        fakeNow = 0L
+        fires.clear()
+        watchdog = AnrWatchdog(
+            onAnr = { durationMs, threads -> fires.add(durationMs to threads) },
+            mainHandler = Handler(Looper.getMainLooper()),
+            clock = { fakeNow }
+        )
+    }
+
+    private fun idleMain() = shadowOf(Looper.getMainLooper()).idle()
+
+    // AC1: main blocked past 5s → exactly one app.anr, all-thread dump with main flagged.
+    @Test
+    fun `blocking main past 5s fires one anr with main flagged dump`() {
+        watchdog.scanOnce()                 // posts the heartbeat; main looper left paused → never runs
+        fakeNow = AnrWatchdog.THRESHOLD_MS  // 5s elapse with no pong
+        watchdog.scanOnce()
+
+        assertEquals(1, fires.size)
+        val (durationMs, threads) = fires.first()
+        assertTrue("duration >= 5000", durationMs >= AnrWatchdog.THRESHOLD_MS)
+        assertTrue("dump flags the main thread", threads.any { it.main })
+    }
+
+    // AC1 (no false positive): main answers before 5s → zero events.
+    @Test
+    fun `main answering before threshold fires nothing`() {
+        watchdog.scanOnce()   // posts heartbeat
+        idleMain()            // main runs the pong → up to date
+        fakeNow = AnrWatchdog.THRESHOLD_MS
+        watchdog.scanOnce()
+
+        assertEquals(0, fires.size)
+    }
+
+    // §6 intra-hang dedup: a 12s block is one event, not one per scan.
+    @Test
+    fun `long hang dedups to a single event`() {
+        watchdog.scanOnce()
+        for (t in longArrayOf(6000, 9000, 12000)) {
+            fakeNow = t
+            watchdog.scanOnce()
+        }
+        assertEquals(1, fires.size)
+
+        // Main recovers, then hangs again → a fresh event (latch cleared by the pong).
+        idleMain()
+        watchdog.scanOnce()                     // re-arm
+        fakeNow += AnrWatchdog.THRESHOLD_MS
+        watchdog.scanOnce()
+        assertEquals(2, fires.size)
+    }
+
+    // AC3: delivered on the durable filesDir rail — frozen app.anr replays and deletes only on a 2xx.
+    @Test
+    fun `frozen anr replays on its own slot and deletes only on 2xx`() {
+        val filesDir = RuntimeEnvironment.getApplication().filesDir
+        FatalCrashStore.delete(filesDir, FatalCrashStore.ANR_FILE_NAME)
+
+        val mockWebServer = MockWebServer()
+        mockWebServer.start()
+        val httpClient = TelemetryHttpClient(mockWebServer.url("/telemetry").toString(), "edge_test", false)
+        try {
+            FatalCrashStore.writeBlocking(
+                filesDir, Gson().toJson(anrBatch()), FatalCrashStore.ANR_FILE_NAME
+            )
+
+            // Non-2xx: file survives for retry. 400 fails immediately (5xx would burn 3 retry+backoff).
+            mockWebServer.enqueue(MockResponse().setResponseCode(400))
+            runBlocking {
+                FatalCrashStore.replayOnce(filesDir, httpClient, Gson(), FatalCrashStore.ANR_FILE_NAME)
+            }
+            assertTrue(FatalCrashStore.file(filesDir, FatalCrashStore.ANR_FILE_NAME).exists())
+
+            // 2xx: is_fatal:false / handled:false on the wire, file deleted.
+            mockWebServer.enqueue(MockResponse().setResponseCode(200))
+            runBlocking {
+                FatalCrashStore.replayOnce(filesDir, httpClient, Gson(), FatalCrashStore.ANR_FILE_NAME)
+            }
+            val body = mockWebServer.takeRequest(5, TimeUnit.SECONDS)!!.body.readUtf8()
+            val wire = JsonParser.parseString(body).asJsonObject
+                .getAsJsonArray("events").get(0).asJsonObject
+            assertEquals("app.anr", wire.get("eventName").asString)
+            val attrs = wire.getAsJsonObject("attributes")
+            assertFalse(attrs.get("is_fatal").asBoolean)
+            assertFalse(attrs.get("handled").asBoolean)
+            assertFalse(FatalCrashStore.file(filesDir, FatalCrashStore.ANR_FILE_NAME).exists())
+        } finally {
+            httpClient.getOkHttpClient().release()
+            mockWebServer.shutdown()
+            FatalCrashStore.delete(filesDir, FatalCrashStore.ANR_FILE_NAME)
+        }
+    }
+
+    private fun anrBatch(): TelemetryBatch = TelemetryBatch(
+        batchSize = 1,
+        timestamp = "2026-07-20T00:00:00.000Z",
+        events = listOf(
+            TelemetryEvent(
+                type = "event",
+                eventName = "app.anr",
+                timestamp = "2026-07-20T00:00:00.000Z",
+                attributes = EventAttributes(
+                    app = AppInfo("TestApp", "1.0.0", "100", "com.test.app"),
+                    device = DeviceInfo(
+                        deviceId = "d", platform = "android", platformVersion = "13",
+                        model = "M", manufacturer = "Mf", brand = "B", androidSdk = "33",
+                        androidRelease = "13", fingerprint = "fp", hardware = "hw", product = "p"
+                    ),
+                    user = UserInfo(userId = "u"),
+                    session = SessionInfo(
+                        sessionId = "s", startTime = "2026-07-20T00:00:00.000Z", durationMs = 1L,
+                        eventCount = 1, metricCount = 0, screenCount = 0, visitedScreens = "",
+                        isFirstSession = true, totalSessions = 1, networkType = "wifi"
+                    ),
+                    customAttributes = mapOf("is_fatal" to false, "handled" to false, "anr.duration_ms" to 5000)
+                )
+            )
+        )
+    )
+}

--- a/telemetry_library/src/test/java/com/androidtel/telemetry_library/core/crash/CrashPathTest.kt
+++ b/telemetry_library/src/test/java/com/androidtel/telemetry_library/core/crash/CrashPathTest.kt
@@ -191,6 +191,44 @@ class CrashPathTest {
         assertTrue(event.attributes.customAttributes.containsKey("crash.thread"))
     }
 
+    // #60: ANR freeze writes a fully-enriched app.anr to its OWN durable slot (separate from the
+    // crash slot), is_fatal:false/handled:false, all-thread dump with main flagged, standard enrichment.
+    @Test
+    fun `anr freeze writes enriched app_anr to its own slot`() {
+        val filesDir = RuntimeEnvironment.getApplication().filesDir
+        com.androidtel.telemetry_library.core.crash.FatalCrashStore.delete(
+            filesDir, com.androidtel.telemetry_library.core.crash.FatalCrashStore.ANR_FILE_NAME
+        )
+        service.initialize(buildAttributesFn = { enrich(it) }, recordCrashEventFn = {})
+
+        val threads = listOf(
+            com.androidtel.telemetry_library.core.anr.ThreadDump("main", "RUNNABLE", true, "at a.b(F:1)"),
+            com.androidtel.telemetry_library.core.anr.ThreadDump("worker", "WAITING", false, "at c.d(F:2)")
+        )
+        service.freezeAnr(durationMs = 5000L, threads = threads)
+
+        // Crash slot untouched; ANR rides its own file.
+        assertNull(FatalCrashStore.readBatch(filesDir, gson))
+        val batch = FatalCrashStore.readBatch(
+            filesDir, gson, com.androidtel.telemetry_library.core.crash.FatalCrashStore.ANR_FILE_NAME
+        )!!
+        val event = batch.events.first()
+        assertEquals("app.anr", event.eventName)
+        assertEquals(crashSessionId, event.attributes.session.sessionId)
+        assertEquals(crashUserId, event.attributes.user.userId)
+        val custom = event.attributes.customAttributes
+        assertEquals(false, custom["is_fatal"])
+        assertEquals(false, custom["handled"])
+        assertTrue(custom.containsKey("anr.duration_ms"))
+        assertTrue(custom.containsKey("screen.name"))
+        // Gson round-trips the dump into a list of maps (customAttributes is Map<String,Any>).
+        @Suppress("UNCHECKED_CAST")
+        val dumped = custom["anr.threads"] as List<Map<String, Any>>
+        assertTrue("dump flags the main thread", dumped.any { it["main"] == true })
+
+        FatalCrashStore.delete(filesDir, com.androidtel.telemetry_library.core.crash.FatalCrashStore.ANR_FILE_NAME)
+    }
+
     // 2. Fatal survives process death: frozen file replays with its ORIGINAL session, and is
     //    deleted only after a 2xx (non-2xx leaves it for retry).
     @Test


### PR DESCRIPTION
Closes #60.

## What
Watchdog-only main-thread ping/pong daemon (API 24+), foreground-only via the existing `ProcessLifecycleOwner` observer. Fixed **5000ms** threshold (internal constant, no config), heartbeat interval 2500ms. On breach: capture an all-thread dump (main flagged) and emit a new `app.anr` event (`is_fatal:false`/`handled:false`) on the crash **durable `filesDir` rail** — replayed and deleted only after a 2xx on next `initialize()`.

## How
- **`core/anr/AnrWatchdog.kt`** (new) — daemon posts a heartbeat to the main `Looper`; if unanswered past the threshold it fires. `scanOnce` seam + injected clock/handler make it deterministic under a fake clock. Intra-hang dedup latches one event per hang until the main thread answers.
- **`FatalCrashStore.kt`** — generalized with a `fileName` param so ANR rides the same freeze → replay → delete-after-2xx invariant on its own slot (`pending_anr.json`), separate from the crash slot so a later fatal crash can't overwrite a pending ANR. `is_fatal:false` distinguishes it downstream.
- **`CrashReportingService.kt`** — owns `freezeAnr`/`replayAnrIfAny` alongside the crash freeze, so the exactly-once discipline has one owner and shares its `gson`.
- **`TelemetryManager.kt`** — builds the watchdog before the lifecycle observer (so a late foregrounded init still arms it), starts on `onStart` / stops on `onStop`, replays a pending ANR at init, and stops the daemon in `resetForTesting`.

## Attribute shape (`app.anr`)
`is_fatal:false`, `handled:false`, `anr.duration_ms` (Long), `screen.name` (repo-canonical key), `anr.threads` (`[{name,state,main,stack}]`), plus standard `session.*`/`user.*`/`sdk.*` enrichment frozen at detection.

## Tests (Robolectric, full suite green)
- Main blocked past 5s → exactly one `app.anr`, all-thread dump with main flagged
- Main answers before 5s → zero events (no false positive)
- 12s block → one event (intra-hang dedup); recovers then re-arms
- Frozen `app.anr` replays on its own slot, deleted only on a 2xx
- Freeze writes a fully-enriched `app.anr` to its slot without touching the crash slot

## Acceptance criteria
- [x] Blocking a fake main thread past 5s emits `app.anr` with an all-thread dump, main flagged (Seam 2, fake clock)
- [x] `app.anr` has `is_fatal:false`/`handled:false`, rides the unified envelope with standard enrichment
- [x] Delivered on the durable `filesDir` rail + replay/delete-after-2xx
- [x] Watchdog runs foreground-only

## Deliberate deviation from spec §5
**Durable-only — no live-batch enqueue.** Spec §5 also enqueues to the live batch for same-session delivery, but doing both double-sends: the live send doesn't delete the disk slot, so replay re-sends it next launch. Durable-only satisfies every acceptance criterion. Trade-off: a surviving-process ANR reports on next launch, not same-session. Upgrade path is documented in `freezeAnr` (enqueue live **and** delete the slot once acked).