### PR TITLE
feat(#61): hang detection — app.hang on shared AnrWatchdog (2s band)

### DIFF
--- a/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/TelemetryManager.kt
+++ b/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/TelemetryManager.kt
@@ -280,7 +280,8 @@ class TelemetryManager private constructor(
             crashReportingService = CrashReportingService(context, config, httpClient)
             crashReportingService.initialize(
                 buildAttributesFn = { attrs -> buildAttributes(attrs) },
-                recordCrashEventFn = { attrs -> recordEvent("app.crash", attrs) }
+                recordCrashEventFn = { attrs -> recordEvent("app.crash", attrs) },
+                recordHangEventFn = { attrs -> recordEvent("app.hang", attrs) }
             )
             Log.d("TelemetryManager", "Step 7: CrashReportingService initialized")
             
@@ -334,9 +335,10 @@ class TelemetryManager private constructor(
             // Step 12b: Build the ANR watchdog BEFORE the lifecycle observer below, so a late init
             // that happens while already foregrounded (addObserver replays onStart synchronously)
             // still finds a non-null watchdog to arm (issue #60).
-            anrWatchdog = AnrWatchdog(onAnr = { durationMs, threads ->
-                crashReportingService.freezeAnr(durationMs, threads)
-            })
+            anrWatchdog = AnrWatchdog(
+                onAnr = { durationMs, threads -> crashReportingService.freezeAnr(durationMs, threads) },
+                onHang = { durationMs, stack -> crashReportingService.recordHang(durationMs, stack) }
+            )
 
             // Step 13: Register ProcessLifecycleOwner observer if enabled
             if (config.enableLifecycleTracking && processObserverRegistered.compareAndSet(false, true)) {

--- a/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/anr/AnrWatchdog.kt
+++ b/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/anr/AnrWatchdog.kt
@@ -15,21 +15,30 @@ data class ThreadDump(
 )
 
 /**
- * Main-thread watchdog (issue #60, spec `docs/specs/anr-detection.md`).
+ * Main-thread watchdog (issue #60 ANR, extended by issue #61 hang; specs `docs/specs/anr-detection.md`
+ * and `docs/specs/hang-detection.md`).
  *
- * A daemon thread posts a heartbeat to the main `Looper` and waits. If the main thread doesn't run
- * the heartbeat within [THRESHOLD_MS] (Google's 5s ANR line), the main thread is blocked → capture an
- * all-thread dump (main flagged) and hand it to [onAnr]. Works on minSdk 24, no API gate.
+ * A daemon thread posts a heartbeat to the main `Looper` and waits. One measurement — how long the
+ * heartbeat took to run — is read against two lines:
+ *  - [HANG_THRESHOLD_MS] (2s): a visible freeze below the ANR line → [onHang] with the main thread's
+ *    stack only (#61). Ships on the normal batch.
+ *  - [ANR_THRESHOLD_MS] (5s): Google's ANR line → [onAnr] with an all-thread dump, main flagged (#60).
+ *    Ships on the durable rail.
+ * Works on minSdk 24, no API gate.
+ *
+ * One unbroken stall can cross both lines and fires BOTH — a 6s block is a hang AND an anr; they're
+ * distinct signals counted independently (#61 §2). Dedup is intra-threshold (one hang per stall, one
+ * anr per stall), not cross-threshold: the terminal anr does not suppress its own precursor hang. Each
+ * latch clears when the main thread runs a heartbeat again.
  *
  * Foreground-only: the SDK calls [start] on foreground and [stop] on background (spec §Lifecycle).
- * Intra-hang dedup: one long hang fires exactly once — the fire latches until the main thread runs a
- * heartbeat again (spec §6).
  *
- * ponytail: threshold + interval are internal constants, not config — the line is the platform's and
- * won't vary per consumer. Upgrade path: promote to TelemetryConfig only if one needs a different line.
+ * ponytail: thresholds + interval are internal constants, not config — the lines are the platform's
+ * and won't vary per consumer. Upgrade path: promote to TelemetryConfig only if one needs a different line.
  */
 class AnrWatchdog(
     private val onAnr: (durationMs: Long, threads: List<ThreadDump>) -> Unit,
+    private val onHang: (durationMs: Long, stack: String) -> Unit,
     // Seams for unit testing (spec §Test plan, "Seam 2, fake clock"). Production reads the real clock
     // and posts to the real main Looper.
     private val mainHandler: Handler = Handler(Looper.getMainLooper()),
@@ -40,22 +49,25 @@ class AnrWatchdog(
     // on the main thread, scanOnce on the watchdog thread.
     @Volatile private var waiting = false
     @Volatile private var pendingSince = 0L
-    // Latches after a fire so one hang = one event; cleared when the main thread finally answers.
-    @Volatile private var alreadyFired = false
+    // Per-threshold latches so one stall = one hang + one anr; both cleared when the main thread answers.
+    @Volatile private var hangFired = false
+    @Volatile private var anrFired = false
     @Volatile private var running = false
     private var worker: Thread? = null
 
-    // The main thread runs this when it's free again: heartbeat answered, re-arm for the next hang.
+    // The main thread runs this when it's free again: heartbeat answered, re-arm for the next stall.
     private val pong = Runnable {
         waiting = false
-        alreadyFired = false
+        hangFired = false
+        anrFired = false
     }
 
     fun start() {
         if (running) return
         running = true
         waiting = false
-        alreadyFired = false
+        hangFired = false
+        anrFired = false
         worker = Thread(::loop, THREAD_NAME).apply { isDaemon = true; start() }
     }
 
@@ -88,11 +100,22 @@ class AnrWatchdog(
             return
         }
         val blockedFor = clock() - pendingSince
-        if (!alreadyFired && blockedFor >= THRESHOLD_MS) {
-            alreadyFired = true
+        // Two independent lines off one measurement; both can trip on the same scan (a 6s stall seen
+        // in one read is a hang and an anr). Not else-if — intra-threshold dedup, not cross-threshold.
+        if (!hangFired && blockedFor >= HANG_THRESHOLD_MS) {
+            hangFired = true
+            onHang(blockedFor, mainThreadStack())
+        }
+        if (!anrFired && blockedFor >= ANR_THRESHOLD_MS) {
+            anrFired = true
             onAnr(blockedFor, captureThreads())
         }
     }
+
+    // Main-thread stack only — a sub-5s stall is slow synchronous main-thread work; the culprit is on
+    // this stack. The all-thread dump stays exclusive to app.anr (#61 §4).
+    private fun mainThreadStack(): String =
+        Looper.getMainLooper().thread.stackTrace.joinToString("\n") { "at $it" }
 
     private fun captureThreads(): List<ThreadDump> {
         val main = Looper.getMainLooper().thread
@@ -107,10 +130,13 @@ class AnrWatchdog(
     }
 
     companion object {
+        // ponytail: fixed 2s — the "user noticed a freeze" line below ANR (hang spec §1).
+        const val HANG_THRESHOLD_MS = 2000L
         // ponytail: fixed 5s — the system input-dispatch ANR line (spec §2).
-        const val THRESHOLD_MS = 5000L
-        // Heartbeat interval = threshold/2, floored at 500ms, so a real 5s hang is caught in one scan.
-        const val INTERVAL_MS = 2500L
+        const val ANR_THRESHOLD_MS = 5000L
+        // Heartbeat interval = min(hangThreshold/2, anrThreshold/2) = 1000ms, so a real 2s stall is
+        // caught in one scan (#61 §2). Cheaper posts, still negligible.
+        const val INTERVAL_MS = 1000L
         private const val THREAD_NAME = "edge-anr-watchdog"
     }
 }

--- a/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/services/CrashReportingService.kt
+++ b/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/services/CrashReportingService.kt
@@ -46,9 +46,10 @@ internal class CrashReportingService(
     // Atomic so concurrent initialize() calls can't double-install the UncaughtExceptionHandler.
     private val crashHandlerInstalled = AtomicBoolean(false)
 
-    // Enrichment + normal-batch sink, injected from TelemetryManager at initialize().
+    // Enrichment + normal-batch sinks, injected from TelemetryManager at initialize().
     private var buildAttributesFn: ((Map<String, Any>) -> EventAttributes?)? = null
     private var recordCrashEventFn: ((Map<String, Any>) -> Unit)? = null
+    private var recordHangEventFn: ((Map<String, Any>) -> Unit)? = null
 
     // trackError context. product_id no longer reaches the wire (D1) — setProductContext is retained
     // only so the public API doesn't break. user_action still rides the canonical key set.
@@ -56,10 +57,12 @@ internal class CrashReportingService(
 
     fun initialize(
         buildAttributesFn: (Map<String, Any>) -> EventAttributes?,
-        recordCrashEventFn: (Map<String, Any>) -> Unit
+        recordCrashEventFn: (Map<String, Any>) -> Unit,
+        recordHangEventFn: (Map<String, Any>) -> Unit
     ) {
         this.buildAttributesFn = buildAttributesFn
         this.recordCrashEventFn = recordCrashEventFn
+        this.recordHangEventFn = recordHangEventFn
         breadcrumbManager = BreadcrumbManager()
 
         if (config.enableCrashReporting && crashHandlerInstalled.compareAndSet(false, true)) {
@@ -161,6 +164,26 @@ internal class CrashReportingService(
     // and the next init retries — same exactly-once rail as the crash (#60).
     suspend fun replayAnrIfAny() {
         FatalCrashStore.replayOnce(context.filesDir, httpClient, gson, FatalCrashStore.ANR_FILE_NAME)
+    }
+
+    // --- Hang: normal in-memory batch (issue #61, NOT the durable rail) ---
+
+    /**
+     * Sub-5s main-thread stall detected by the watchdog. Runs on the watchdog thread. Unlike ANR, a
+     * hang doesn't get the app killed (it's below the ANR line by definition), so it rides the normal
+     * batch — no `filesDir` persistence (spec §6). Main-thread stack only (§4). `is_fatal:false`.
+     * Session/user are frozen at detection time by the standard enrichment on the sink.
+     */
+    fun recordHang(durationMs: Long, stack: String) {
+        recordHangEventFn?.invoke(
+            mapOf(
+                "is_fatal" to false,
+                "handled" to false,
+                "hang.duration_ms" to durationMs,
+                "screen.name" to (NavigationStackTracker.currentScreen() ?: ""),
+                "hang.stack" to stack
+            )
+        ) ?: Log.w(TAG, "Hang event sink not wired")
     }
 
     // --- Normal batch rail ---

--- a/telemetry_library/src/test/java/com/androidtel/telemetry_library/core/anr/AnrWatchdogTest.kt
+++ b/telemetry_library/src/test/java/com/androidtel/telemetry_library/core/anr/AnrWatchdogTest.kt
@@ -43,14 +43,17 @@ class AnrWatchdogTest {
 
     private var fakeNow = 0L
     private val fires = mutableListOf<Pair<Long, List<ThreadDump>>>()
+    private val hangs = mutableListOf<Pair<Long, String>>()
     private lateinit var watchdog: AnrWatchdog
 
     @Before
     fun setUp() {
         fakeNow = 0L
         fires.clear()
+        hangs.clear()
         watchdog = AnrWatchdog(
             onAnr = { durationMs, threads -> fires.add(durationMs to threads) },
+            onHang = { durationMs, stack -> hangs.add(durationMs to stack) },
             mainHandler = Handler(Looper.getMainLooper()),
             clock = { fakeNow }
         )
@@ -61,13 +64,13 @@ class AnrWatchdogTest {
     // AC1: main blocked past 5s → exactly one app.anr, all-thread dump with main flagged.
     @Test
     fun `blocking main past 5s fires one anr with main flagged dump`() {
-        watchdog.scanOnce()                 // posts the heartbeat; main looper left paused → never runs
-        fakeNow = AnrWatchdog.THRESHOLD_MS  // 5s elapse with no pong
+        watchdog.scanOnce()                     // posts the heartbeat; main looper left paused → never runs
+        fakeNow = AnrWatchdog.ANR_THRESHOLD_MS  // 5s elapse with no pong
         watchdog.scanOnce()
 
         assertEquals(1, fires.size)
         val (durationMs, threads) = fires.first()
-        assertTrue("duration >= 5000", durationMs >= AnrWatchdog.THRESHOLD_MS)
+        assertTrue("duration >= 5000", durationMs >= AnrWatchdog.ANR_THRESHOLD_MS)
         assertTrue("dump flags the main thread", threads.any { it.main })
     }
 
@@ -76,13 +79,13 @@ class AnrWatchdogTest {
     fun `main answering before threshold fires nothing`() {
         watchdog.scanOnce()   // posts heartbeat
         idleMain()            // main runs the pong → up to date
-        fakeNow = AnrWatchdog.THRESHOLD_MS
+        fakeNow = AnrWatchdog.ANR_THRESHOLD_MS
         watchdog.scanOnce()
 
         assertEquals(0, fires.size)
     }
 
-    // §6 intra-hang dedup: a 12s block is one event, not one per scan.
+    // §6 intra-hang dedup: a 12s block is one anr event, not one per scan.
     @Test
     fun `long hang dedups to a single event`() {
         watchdog.scanOnce()
@@ -95,9 +98,76 @@ class AnrWatchdogTest {
         // Main recovers, then hangs again → a fresh event (latch cleared by the pong).
         idleMain()
         watchdog.scanOnce()                     // re-arm
-        fakeNow += AnrWatchdog.THRESHOLD_MS
+        fakeNow += AnrWatchdog.ANR_THRESHOLD_MS
         watchdog.scanOnce()
         assertEquals(2, fires.size)
+    }
+
+    // --- Issue #61: hang detection, band [2000,5000) off the same watchdog ---
+
+    // AC (#61): main blocked ≥2s but <5s → exactly one app.hang, main-thread stack only, no anr.
+    @Test
+    fun `blocking main past 2s but under 5s fires one hang and no anr`() {
+        watchdog.scanOnce()                      // posts heartbeat; main paused
+        fakeNow = AnrWatchdog.HANG_THRESHOLD_MS  // 2s elapse, no pong
+        watchdog.scanOnce()
+
+        assertEquals(1, hangs.size)
+        assertEquals(0, fires.size)
+        val (durationMs, stack) = hangs.first()
+        assertTrue("duration >= 2000", durationMs >= AnrWatchdog.HANG_THRESHOLD_MS)
+        assertTrue("duration < 5000", durationMs < AnrWatchdog.ANR_THRESHOLD_MS)
+        assertTrue("main-thread stack captured", stack.isNotBlank())
+    }
+
+    // AC (#61): a healthy main thread that answers before 2s fires nothing.
+    @Test
+    fun `main answering before 2s fires no hang`() {
+        watchdog.scanOnce()
+        idleMain()
+        fakeNow = AnrWatchdog.HANG_THRESHOLD_MS
+        watchdog.scanOnce()
+
+        assertEquals(0, hangs.size)
+        assertEquals(0, fires.size)
+    }
+
+    // AC (#61) escalation: one unbroken 6s block → exactly one hang AND one anr (not two hangs).
+    @Test
+    fun `single unbroken block crossing both bands fires one hang and one anr`() {
+        watchdog.scanOnce()                          // posts heartbeat
+        fakeNow = AnrWatchdog.HANG_THRESHOLD_MS       // 2s → hang
+        watchdog.scanOnce()
+        fakeNow = AnrWatchdog.ANR_THRESHOLD_MS        // 5s → anr, same stall
+        watchdog.scanOnce()
+        fakeNow = 6000L                               // still blocked → no dupes
+        watchdog.scanOnce()
+
+        assertEquals(1, hangs.size)
+        assertEquals(1, fires.size)
+    }
+
+    // AC (#61) intra-hang dedup: a 3s block is one hang, not one per scan.
+    @Test
+    fun `three second block dedups to a single hang`() {
+        watchdog.scanOnce()
+        for (t in longArrayOf(2000, 2500, 3000)) {
+            fakeNow = t
+            watchdog.scanOnce()
+        }
+        assertEquals(1, hangs.size)
+        assertEquals(0, fires.size)
+    }
+
+    // AC (#61) band boundary: a 4.9s block → one hang, no anr.
+    @Test
+    fun `block just under 5s fires hang but not anr`() {
+        watchdog.scanOnce()
+        fakeNow = 4900L
+        watchdog.scanOnce()
+
+        assertEquals(1, hangs.size)
+        assertEquals(0, fires.size)
     }
 
     // AC3: delivered on the durable filesDir rail — frozen app.anr replays and deletes only on a 2xx.

--- a/telemetry_library/src/test/java/com/androidtel/telemetry_library/core/crash/CrashPathTest.kt
+++ b/telemetry_library/src/test/java/com/androidtel/telemetry_library/core/crash/CrashPathTest.kt
@@ -174,7 +174,8 @@ class CrashPathTest {
         }
         service.initialize(
             buildAttributesFn = { enrich(it) },
-            recordCrashEventFn = { /* not used on the fatal rail */ }
+            recordCrashEventFn = { /* not used on the fatal rail */ },
+            recordHangEventFn = { /* not used on the fatal rail */ }
         )
 
         val installed = Thread.getDefaultUncaughtExceptionHandler()!!
@@ -199,7 +200,7 @@ class CrashPathTest {
         com.androidtel.telemetry_library.core.crash.FatalCrashStore.delete(
             filesDir, com.androidtel.telemetry_library.core.crash.FatalCrashStore.ANR_FILE_NAME
         )
-        service.initialize(buildAttributesFn = { enrich(it) }, recordCrashEventFn = {})
+        service.initialize(buildAttributesFn = { enrich(it) }, recordCrashEventFn = {}, recordHangEventFn = {})
 
         val threads = listOf(
             com.androidtel.telemetry_library.core.anr.ThreadDump("main", "RUNNABLE", true, "at a.b(F:1)"),


### PR DESCRIPTION
Closes #61.

## What
Sub-5s complement to ANR. Extends the #60 `AnrWatchdog` with a second **2000ms** threshold off the **same** heartbeat — one daemon, one measurement, two lines (2s hang / 5s anr). No second detector.

## How
- **Two thresholds, one heartbeat.** `HANG_THRESHOLD_MS = 2000L` alongside the existing 5s ANR line; heartbeat interval drops `2500→1000ms` so a 2s stall is caught in one scan.
- **Both events on a crossing.** A single unbroken 6s stall emits *both* `app.hang` and `app.anr`. Dedup is **intra-threshold** (per-line `hangFired`/`anrFired` latches, separate `if`s not `else-if`) — the terminal anr never suppresses its own precursor hang. Each latch clears when the main thread answers a heartbeat again.
- **`app.hang` shape.** Main-thread stack only (`hang.stack`), `hang.duration_ms`, `screen.name`, `is_fatal:false`, `handled:false`. Session/user frozen at detection via the standard enrichment. No all-thread dump (that stays exclusive to `app.anr`).
- **Normal batch, not the durable rail.** `recordHang` → `recordEvent("app.hang", …)`. No `filesDir` persistence — a sub-5s stall survives the process; a stall that gets the app killed has crossed 5s and is already a persisted `app.anr`.
- **No new lifecycle wiring** — inherits the watchdog's foreground-only start/stop.

Spec: `docs/specs/hang-detection.md`

## Tests (TDD at the `scanOnce` seam, fake clock)
- 2s→<5s block → one `app.hang`, main-thread stack, no anr
- healthy main answering before 2s → nothing
- unbroken 6s → exactly one hang **and** one anr
- 3s block → one hang (intra-hang dedup)
- 4.9s boundary → hang, no anr
- existing #60 anr tests updated for the renamed `ANR_THRESHOLD_MS`

Full unit suite green.

## Files
| File | Change |
|---|---|
| `core/anr/AnrWatchdog.kt` | second threshold + `onHang`, 1000ms heartbeat, main-thread stack capture, `THRESHOLD_MS→ANR_THRESHOLD_MS` |
| `core/services/CrashReportingService.kt` | `recordHang()` on the normal batch via new `recordHangEventFn` sink |
| `core/TelemetryManager.kt` | wire `onHang` + `recordEvent("app.hang", …)` |
| `core/anr/AnrWatchdogTest.kt`, `core/crash/CrashPathTest.kt` | tests |