### PR TITLE
feat(#62): Seam 3 CI source-grep guards — deleted symbols stay deleted

### DIFF
--- a/telemetry_library/src/test/java/com/androidtel/telemetry_library/core/DeletedSymbolGuardTest.kt
+++ b/telemetry_library/src/test/java/com/androidtel/telemetry_library/core/DeletedSymbolGuardTest.kt
@@ -1,0 +1,59 @@
+package com.androidtel.telemetry_library.core
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+/**
+ * #62 Seam 3 static fence: fails if a symbol the dead-code removal deleted
+ * ([docs/specs/dead-code-removal.md]) reappears anywhere in `src/main`. The
+ * removals compiled clean because nothing live referenced them; this guard
+ * keeps a removed footgun (geo-IP provider, full-URL interceptor, dead payload
+ * wrappers) from silently returning under a future edit.
+ *
+ * The timezone/`Instant.now()` half of the Seam 3 fence lives in
+ * [TimestampSourceGuardTest] (#41) — this file only covers deleted symbols.
+ *
+ * ponytail: a grep-in-a-test, not new tooling — rides the existing
+ * testDebugUnitTest gate (#31).
+ */
+class DeletedSymbolGuardTest {
+
+    // Deleted classes/config from dead-code-removal.md items A–F (+ crash Path B, #56).
+    // Word-boundary match: substrings of live names (EventPayloadValidator, etc.) don't trip it.
+    private val deletedSymbols = listOf(
+        "IpLocationProvider",              // A: geo-IP stack
+        "LocationProvider",                // A: 9-line interface, only IpLocationProvider implemented it
+        "enableLocationTracking",          // A: no-op config flag
+        "JsonEventTracker",                // B
+        "testConnectivity",                // B: dead public debug method on TelemetryManager
+        "LegacyPerformanceTracker",        // C
+        "LegacyPerformanceTrackerWrapper", // C: dead wrapper class
+        "EdgeTelemetryInterceptor",        // D: leaked full URL incl. query
+        "TelemetryPayload",                // E: dead wrapper
+        "EventBatchPayload",               // F: unused batch payload
+        "createEventBatchPayload",         // F: its factory
+        "FlutterCompatiblePayload",        // crash Path B retirement (#56)
+    )
+
+    private val srcMain: File =
+        listOf(File("src/main"), File("telemetry_library/src/main"))
+            .first { it.isDirectory }
+
+    private fun kotlinSources(): List<File> =
+        srcMain.walkTopDown().filter { it.isFile && it.extension == "kt" }.toList()
+
+    @Test
+    fun `no deleted dead-code symbol reappears in src-main`() {
+        val offenders = kotlinSources().flatMap { file ->
+            val text = file.readText()
+            deletedSymbols
+                .filter { Regex("\\b${Regex.escape(it)}\\b").containsMatchIn(text) }
+                .map { "${file.name}: $it" }
+        }
+        assertTrue(
+            "Deleted dead-code symbols must stay deleted (see dead-code-removal.md); found: $offenders",
+            offenders.isEmpty()
+        )
+    }
+}


### PR DESCRIPTION
Closes #62.

## What
Adds `DeletedSymbolGuardTest` — a grep-in-a-test that fails if any symbol the dead-code removal deleted reappears in `src/main`. Cheap static fence so a removed footgun (geo-IP provider, full-URL interceptor, dead payload wrappers) can't silently return.

Guarded symbols (12), from `docs/specs/dead-code-removal.md` items A–F + crash Path B (#56):
`IpLocationProvider`, `LocationProvider`, `enableLocationTracking`, `JsonEventTracker`, `testConnectivity`, `LegacyPerformanceTracker`, `LegacyPerformanceTrackerWrapper`, `EdgeTelemetryInterceptor`, `TelemetryPayload`, `EventBatchPayload`, `createEventBatchPayload`, `FlutterCompatiblePayload`.

Word-boundary regex so live substrings (`EventPayloadValidator`, …) don't trip it.

## Acceptance criteria
- [x] Fails on any timezone-less `SimpleDateFormat` — already covered by `TimestampSourceGuardTest` (#41)
- [x] Fails on any `Instant.now()` — already covered by `TimestampSourceGuardTest` (#41)
- [x] Fails if any deleted symbol reappears — this PR
- [x] Runs in the existing CI job (`testDebugUnitTest`); green against `master`

## Notes
The timezone/`Instant.now()` half of the Seam 3 fence already exists in `TimestampSourceGuardTest`, so this PR only adds the missing deleted-symbol guard rather than duplicating it. No CI workflow changes — both guards ride the existing `testDebugUnitTest` step.