### PR TITLE
docs: scrub Flutter framework names from source comments

### DIFF
--- a/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/TelemetryManager.kt
+++ b/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/TelemetryManager.kt
@@ -862,7 +862,7 @@ class TelemetryManager private constructor(
     }
 
     // ================================
-    // Flutter-Compatible Public API
+    // Backend-Compatible Public API
     // ================================
 
     /**

--- a/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/breadcrumbs/Breadcrumb.kt
+++ b/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/breadcrumbs/Breadcrumb.kt
@@ -3,7 +3,7 @@ package com.androidtel.telemetry_library.core.breadcrumbs
 import com.androidtel.telemetry_library.core.TelemetryTime
 
 /**
- * Breadcrumb data structure matching Flutter SDK format
+ * Breadcrumb data structure matching backend collector format
  */
 data class Breadcrumb(
     val message: String,
@@ -31,7 +31,7 @@ data class Breadcrumb(
 }
 
 /**
- * Breadcrumb categories matching Flutter SDK
+ * Breadcrumb categories matching the backend collector
  */
 object BreadcrumbCategory {
     const val NAVIGATION = "navigation"
@@ -43,7 +43,7 @@ object BreadcrumbCategory {
 }
 
 /**
- * Breadcrumb levels matching Flutter SDK
+ * Breadcrumb levels matching the backend collector
  */
 object BreadcrumbLevel {
     const val DEBUG = "debug"

--- a/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/breadcrumbs/BreadcrumbManager.kt
+++ b/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/breadcrumbs/BreadcrumbManager.kt
@@ -10,7 +10,7 @@ import kotlin.concurrent.write
 
 /**
  * Breadcrumb Manager that maintains a circular buffer of breadcrumbs
- * with thread-safe operations and JSON serialization matching Flutter SDK
+ * with thread-safe operations and JSON serialization matching the backend collector
  */
 class BreadcrumbManager {
     

--- a/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/crash/CrashFingerprinter.kt
+++ b/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/crash/CrashFingerprinter.kt
@@ -1,7 +1,7 @@
 package com.androidtel.telemetry_library.core.crash
 
 /**
- * Crash fingerprinting algorithm that matches the Flutter SDK exactly
+ * Crash fingerprinting algorithm that matches the backend collector exactly
  */
 object CrashFingerprinter {
     

--- a/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/device/DeviceInfoCollector.kt
+++ b/telemetry_library/src/main/java/com/androidtel/telemetry_library/core/device/DeviceInfoCollector.kt
@@ -10,7 +10,7 @@ import com.androidtel.telemetry_library.core.ids.IdGenerator
 
 /**
  * Device Information Collector that provides comprehensive device attributes
- * matching the Flutter SDK payload structure exactly
+ * matching the backend collector payload structure exactly
  */
 class DeviceInfoCollector(
     private val context: Context,


### PR DESCRIPTION
Follow-up to #62 / #83.

Rewords the remaining `matching Flutter SDK` comment/doc-strings to `backend collector`. These comments describe the SDK's wire-format compatibility with the backend collector — there is no Flutter dependency. Keeps the source free of framework names.

Comment-only; no code change. 5 files, 7 lines.